### PR TITLE
Fix type annotations for modern MoonBit syntax

### DIFF
--- a/base64/base64.mbt
+++ b/base64/base64.mbt
@@ -58,7 +58,7 @@ pub fn Encoder::new() -> Encoder {
 #locals(cb)
 pub fn Encoder::encode_to(
   self : Encoder,
-  bytes : @bytes.View,
+  bytes : BytesView,
   cb : (Char) -> Unit,
   url_safe? : Bool = false,
   padding? : Bool = false,
@@ -105,7 +105,7 @@ pub fn Encoder::encode_to(
 
 ///|
 /// Encode binary to ascii text following  defined in RFC 4648
-pub fn encode(bytes : @bytes.View, url_safe? : Bool = false) -> String {
+pub fn encode(bytes : BytesView, url_safe? : Bool = false) -> String {
   let builder = StringBuilder::new()
   let encoder = Encoder::new()
   encoder.encode_to(
@@ -132,7 +132,7 @@ pub fn Decoder::new() -> Decoder {
 #locals(cb)
 pub fn Decoder::decode_to(
   self : Decoder,
-  input : @string.View,
+  input : StringView,
   cb : (Byte) -> Unit,
   url_safe? : Bool = false,
 ) -> Unit raise DecodeError {
@@ -167,7 +167,7 @@ pub fn Decoder::decode_to(
 
 ///|
 pub fn decode(
-  input : @string.View,
+  input : StringView,
   url_safe? : Bool = false,
 ) -> Bytes raise DecodeError {
   let decoder = Decoder::new()

--- a/base64/base64_wbtest.mbt
+++ b/base64/base64_wbtest.mbt
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 ///|
-struct CustomBytes(@bytes.View)
+struct CustomBytes(BytesView)
 
 ///|
 impl Show for CustomBytes with output(self, logger) {

--- a/readline/unicode/width/README.mbt.md
+++ b/readline/unicode/width/README.mbt.md
@@ -34,7 +34,7 @@ Returns the UAX #11 based width of a character, or `None` if the character is a 
   - `cjk`: If `true`, ambiguous width characters are treated as wide (CJK context). If `false`, they are treated as narrow. Defaults to `false`.
 - **Returns:** The width of the character, or `None` if it's a control character
 
-#### `str_width(s : @string.View, cjk? : Bool = false) -> Int`
+#### `str_width(s : StringView, cjk? : Bool = false) -> Int`
 
 Returns the UAX #11 based width of a string.
 

--- a/readline/unicode/width/scripts/unicode.py
+++ b/readline/unicode/width/scripts/unicode.py
@@ -1553,7 +1553,7 @@ def lookup_fns(
     }}
 }}
 
-{cfg}fn str_width{cjk_lo}_impl(s : @string.View) -> Int {{
+{cfg}fn str_width{cjk_lo}_impl(s : StringView) -> Int {{
     s.rev_iter().fold(
         init=(0, default_width_info),
         fn(acc, c) {{

--- a/readline/unicode/width/tables.mbt
+++ b/readline/unicode/width/tables.mbt
@@ -693,7 +693,7 @@ fn width_in_str(c : Char, next_info : WidthInfo) -> (Int, WidthInfo) {
 }
 
 ///|
-fn str_width_impl(s : @string.View) -> Int {
+fn str_width_impl(s : StringView) -> Int {
   s
   .rev_iter()
   .fold(init=(0, default_width_info), fn(acc, c) {
@@ -1096,7 +1096,7 @@ fn width_in_str_cjk(c : Char, next_info : WidthInfo) -> (Int, WidthInfo) {
 // CJK variant
 
 ///|
-fn str_width_cjk_impl(s : @string.View) -> Int {
+fn str_width_cjk_impl(s : StringView) -> Int {
   s
   .rev_iter()
   .fold(init=(0, default_width_info), fn(acc, c) {

--- a/readline/unicode/width/unicodewidth.mbt
+++ b/readline/unicode/width/unicodewidth.mbt
@@ -24,6 +24,6 @@ pub fn char(c : Char, cjk? : Bool = false) -> Int? {
 /// @param cjk If true, ambiguous width characters are treated as wide (CJK context).
 ///            If false, they are treated as narrow. Defaults to true.
 /// @return The total width of the string
-pub fn string(s : @string.View, cjk? : Bool = false) -> Int {
+pub fn string(s : StringView, cjk? : Bool = false) -> Int {
   (if cjk { str_width_cjk_impl } else { str_width_impl })(s)
 }

--- a/tiktoken/encoding.mbt
+++ b/tiktoken/encoding.mbt
@@ -96,7 +96,7 @@ fn Encoding::merge(self : Encoding, tokens : Array[Int]) -> Unit {
 ///|
 pub fn Encoding::encode(
   self : Encoding,
-  piece : @string.View,
+  piece : StringView,
 ) -> Array[Int] raise {
   let tokens = []
   let matches = self.regex.matches(piece)


### PR DESCRIPTION
## Summary

This PR updates type annotations throughout the codebase to use modern MoonBit syntax.

## Changes

- Replace `@bytes.View` with `BytesView`
- Replace `@string.View` with `StringView`

## Files Modified

- `base64/base64.mbt` - Updated encoding/decoding function signatures
- `base64/base64_wbtest.mbt` - Updated test struct
- `readline/unicode/width/README.mbt.md` - Updated documentation
- `readline/unicode/width/scripts/unicode.py` - Updated generated code templates
- `readline/unicode/width/tables.mbt` - Updated width calculation functions
- `readline/unicode/width/unicodewidth.mbt` - Updated public API
- `tiktoken/encoding.mbt` - Updated encoding function signature

## Testing

- ✅ All 154 tests pass
- ✅ Code compiles without warnings
- ✅ `moon check` passes
- ✅ `moon fmt` applied

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

This is a modernization update to align with current MoonBit language conventions.