### PR TITLE
Rename Failure to ToolFailure for better error naming

### DIFF
--- a/tool/tool.mbt
+++ b/tool/tool.mbt
@@ -35,10 +35,10 @@ pub fn Result::output(self : Result) -> Json {
 }
 
 ///|
-priv suberror Failure Json derive(ToJson)
+priv suberror ToolFailure Json derive(ToJson)
 
 ///|
-pub fn error(output : Json, error? : Error = Failure(output)) -> Result {
+pub fn error(output : Json, error? : Error = ToolFailure(output)) -> Result {
   Error(error, output)
 }
 

--- a/tools/read_file/read_file_test.mbt
+++ b/tools/read_file/read_file_test.mbt
@@ -12,7 +12,7 @@ async test "nonexistent" (t : @test.T) {
       fail("Expected an error for nonexistent file")
     }
     @json.inspect(error, content=[
-      "Failure", "Error reading file: File not found: nonexistent.txt",
+      "ToolFailure", "Error reading file: File not found: nonexistent.txt",
     ])
   })
 }

--- a/tools/todo_write/tool_test.mbt
+++ b/tools/todo_write/tool_test.mbt
@@ -443,7 +443,7 @@ async test "todo_write/mark_completed" (t : @test.T) {
     )
     @json.inspect(result, content=[
       "Error",
-      ["Failure", "Error: Task with ID 'nonexistent' not found."],
+      ["ToolFailure", "Error: Task with ID 'nonexistent' not found."],
       "Error: Task with ID 'nonexistent' not found.",
     ])
     let result = @todo_write.todo_write.call(
@@ -568,7 +568,7 @@ async test "todo_write/mark_progress" (t : @test.T) {
     )
     @json.inspect(result, content=[
       "Error",
-      ["Failure", "Error: Task with ID 'nonexistent' not found."],
+      ["ToolFailure", "Error: Task with ID 'nonexistent' not found."],
       "Error: Task with ID 'nonexistent' not found.",
     ])
     inspect(

--- a/tools/write_to_file/write_to_file_test.mbt
+++ b/tools/write_to_file/write_to_file_test.mbt
@@ -66,7 +66,7 @@ async test "write_to_file/fail-to-match" (t : @test.T) {
     @json.inspect(result, content=[
       "Error",
       [
-        "Failure", "Search content not found in file (tried all matching strategies): Non-matching content",
+        "ToolFailure", "Search content not found in file (tried all matching strategies): Non-matching content",
       ],
       "Search content not found in file (tried all matching strategies): Non-matching content",
     ])


### PR DESCRIPTION
This PR renames the `Failure` error type to `ToolFailure` for better clarity and consistency in error handling across tools.

## Changes:
- Updated tool error type from `Failure` to `ToolFailure` in `tool/tool.mbt`
- Updated corresponding test assertions in:
  - `tools/read_file/read_file_test.mbt`
  - `tools/todo_write/tool_test.mbt`
  - `tools/write_to_file/write_to_file_test.mbt`

## Benefits:
- Improves clarity by making the error type name more descriptive
- Maintains consistency across the codebase
- Makes it clearer that this is a tool-specific failure type

The changes are minimal and focused on renaming the error type while preserving all existing functionality.