### PR TITLE
Start logger in Maria

### DIFF
--- a/maria.mbt
+++ b/maria.mbt
@@ -155,6 +155,9 @@ pub fn Maria::close(self : Maria) -> Unit {
 
 ///|
 pub async fn Maria::start(self : Maria, prompt : String) -> Unit {
-  self.agent.add_message(@openai.user_message(content=prompt))
-  self.agent.start()
+  @async.with_task_group(group => {
+    group.spawn_bg(() => self.logger.start(), no_wait=true)
+    self.agent.add_message(@openai.user_message(content=prompt))
+    self.agent.start()
+  })
 }

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -16,6 +16,7 @@
     "moonbitlang/maria/tools/todo_write",
     "moonbitlang/maria/tools/search_files",
     "moonbitlang/maria/prompt",
-    "moonbitlang/maria/job"
+    "moonbitlang/maria/job",
+    "moonbitlang/async"
   ]
 }


### PR DESCRIPTION
Now maria fails to logging to .moonagent/log, b/c starting logger is often forgetted when writing async main