### PR TITLE
fix(mock): increase default timeout to 10 min

### DIFF
--- a/internal/mock/taco.mbt
+++ b/internal/mock/taco.mbt
@@ -283,7 +283,7 @@ let os_args : Array[String] = @os.args()
 pub async fn run(
   t : @test.T,
   loc~ : SourceLoc,
-  timeout? : Int = 30_000,
+  timeout? : Int = 600_000,
   retry? : Int,
   f : async (Context) -> Unit,
 ) -> Unit {

--- a/internal/moon/coverage_test.mbt
+++ b/internal/moon/coverage_test.mbt
@@ -74,7 +74,7 @@ async test "Coverage::report" (t : @test.T) {
 
 ///|
 async test "Coverage::analyze" (t : @test.T) {
-  @mock.run(t, timeout=300_000, taco => {
+  @mock.run(t, taco => {
     taco.add_files([
       (
         "moon.mod.json",
@@ -146,7 +146,7 @@ async test "Coverage::analyze" (t : @test.T) {
 
 ///|
 async test "Coverage::clean" (t : @test.T) {
-  @mock.run(t, timeout=300_000, taco => {
+  @mock.run(t, taco => {
     taco.add_files([
       (
         "moon.mod.json",

--- a/tools/search_files/tool_test.mbt
+++ b/tools/search_files/tool_test.mbt
@@ -37,7 +37,7 @@ async test "search_files" (t : @test.T) {
 
 ///|
 async test "search_files/agentic" (t : @test.T) {
-  @mock.run(t, timeout=300_000, taco => {
+  @mock.run(t, taco => {
     guard @os.getenv("OPENAI_API_KEY") is Some(api_key) else {
       fail("OPENAI_API_KEY not set")
     }

--- a/tools/write_to_file/write_to_file_test.mbt
+++ b/tools/write_to_file/write_to_file_test.mbt
@@ -109,7 +109,7 @@ async test "write_to_file/search-replace" (t : @test.T) {
 ///|
 async test "write_to_file/agentic" (t : @test.T) {
   // TODO: add retries support
-  @mock.run(timeout=60_000, retry=3, t, taco => {
+  @mock.run(retry=3, t, taco => {
     guard @os.getenv("OPENAI_API_KEY") is Some(api_key) else {
       fail("OPENAI_API_KEY not set")
     }


### PR DESCRIPTION
It is often the case that test like "Coverage::analyze" times-out and fails CI. After digging into the issue, such timeout is usually caused by:

1. asynchronous test are running in parallel.
2. Some of the async test spawns `moon`.
3. `moon` internally use a lock-file mechanism, which means when an asynchronous test spawns a `moon` process, it has to wait for prior spawned `moon` to exit. This time will be recorded as part of the execution time of current task, and causes the task to time-out.

This PR works around this issue by increase the default timeout of mocked test to be 10-min. But this issue has to be solved somehow as we are adding more and more tests and the lock contention will be more severe.