### PR TITLE
refactor(agent): use enum for events

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -1,43 +1,54 @@
 ///|
 /// Event type that occurs during agent conversation lifecycle.
-pub(all) enum Event {
-  ConversationStart
-  ConversationEnd
-  PreToolCall
-  PostToolCall
-  TokenCounted
-  RequestCompleted
-} derive(Eq, Hash)
+pub enum Event {
+  PreConversation
+  PostConversation
+  MessageAdded(@openai.ChatCompletionMessageParam)
+  PreToolCall(@openai.ChatCompletionMessageToolCall)
+  PostToolCall(
+    @openai.ChatCompletionMessageToolCall,
+    result~ : @tool.Result,
+    rendered~ : String
+  )
+  TokenCounted(Int)
+  ContextPruned(origin_token_count~ : Int, pruned_token_count~ : Int)
+  RequestCompleted(
+    usage~ : @openai.CompletionUsage?,
+    message~ : @openai.ChatCompletionMessage
+  )
+}
 
 ///|
-pub struct EventContext {
-  usage : @openai.CompletionUsage?
-  message : @openai.ChatCompletionMessage?
-  origin_token_count : Int?
-  pruned_token_count : Int?
-  tool_call : @openai.ChatCompletionMessageToolCall?
-  tool_call_result : @tool.Result?
-  tool_call_result_text : String?
-} derive(ToJson)
+priv struct EventTarget {
+  queue : @aqueue.Queue[Event]
+  listeners : Array[async (Event) -> Unit]
+}
 
 ///|
-fn EventContext::new(
-  usage? : @openai.CompletionUsage,
-  message? : @openai.ChatCompletionMessage,
-  origin_token_count? : Int,
-  pruned_token_count? : Int,
-  tool_call? : @openai.ChatCompletionMessageToolCall,
-  tool_call_result? : @tool.Result,
-  tool_call_result_text? : String,
-) -> EventContext {
-  EventContext::{
-    usage,
-    message,
-    origin_token_count,
-    pruned_token_count,
-    tool_call,
-    tool_call_result,
-    tool_call_result_text,
+fn EventTarget::new() -> EventTarget {
+  EventTarget::{ queue: @aqueue.Queue::new(), listeners: [] }
+}
+
+///|
+fn EventTarget::emit(self : EventTarget, event : Event) -> Unit {
+  self.queue.put(event)
+}
+
+///|
+fn EventTarget::add_listener(
+  self : EventTarget,
+  f : async (Event) -> Unit,
+) -> Unit {
+  self.listeners.push(f)
+}
+
+///|
+async fn EventTarget::start(self : EventTarget) -> Unit {
+  while true {
+    let event = self.queue.get()
+    for listener in self.listeners {
+      listener(event)
+    }
   }
 }
 
@@ -47,10 +58,11 @@ pub struct Agent {
   uuid : @uuid.Generator
   cwd : String
   model : @model.Model
+  priv logger : @pino.Logger
   priv tools : Map[String, @tool.Tool[Unit]]
   priv history : @conversation.Conversation
   priv mut queue : Array[@openai.ChatCompletionMessageParam]
-  priv event_target : @event.Target[Event, EventContext]
+  priv event_target : EventTarget
   priv token_counter : @token.Counter
   priv context_pruner : @context.Pruner
   priv session_manager : @conversation.Manager
@@ -65,6 +77,7 @@ pub fn Agent::add_message(
   message : @openai.ChatCompletionMessageParam,
 ) -> Unit {
   agent.queue.push(message)
+  agent.emit(MessageAdded(message))
 }
 
 ///|
@@ -109,6 +122,7 @@ async fn Agent::call(agent : Agent) -> @openai.ChatCompletionMessage {
       usage=@openai.usage(include_=true),
     ),
   )
+  agent.emit(TokenCounted(origin_token_count))
   let messages = agent.context_pruner.prune_messages(messages)
   let pruned_token_count = agent.token_counter.count_param(
     @openai.chat_completion(
@@ -118,10 +132,7 @@ async fn Agent::call(agent : Agent) -> @openai.ChatCompletionMessage {
       usage=@openai.usage(include_=true),
     ),
   )
-  agent.emit(
-    TokenCounted,
-    EventContext::new(origin_token_count~, pruned_token_count~),
-  )
+  agent.emit(ContextPruned(origin_token_count~, pruned_token_count~))
   let messages = @cache.cache_messages(messages)
   let request = @openai.chat_completion(
     messages~,
@@ -131,10 +142,7 @@ async fn Agent::call(agent : Agent) -> @openai.ChatCompletionMessage {
   let response = @openai.chat(model=agent.model, request)
   guard response.choices is [choice, ..] else { raise EmptyChoices }
   let message = choice.message
-  agent.emit(
-    RequestCompleted,
-    EventContext::new(usage?=response.usage, message~),
-  )
+  agent.emit(RequestCompleted(usage=response.usage, message~))
   for message in staged {
     agent.history.add_message(message)
   }
@@ -154,7 +162,7 @@ async fn Agent::execute_tool(
       tool_call_id=tool_call.id,
     )
   }
-  agent.emit(PreToolCall, EventContext::new(tool_call~))
+  agent.emit(PreToolCall(tool_call))
   let arguments = @json.parse(tool_call.function.arguments) catch {
     error =>
       return @openai.tool_message(
@@ -164,14 +172,7 @@ async fn Agent::execute_tool(
   }
   let result = tool.call(arguments, ())
   let rendered = (tool.render)(result)
-  agent.emit(
-    PostToolCall,
-    EventContext::new(
-      tool_call~,
-      tool_call_result=result,
-      tool_call_result_text=rendered,
-    ),
-  )
+  agent.emit(PostToolCall(tool_call, result~, rendered~))
   @openai.tool_message(content=rendered, tool_call_id=tool_call.id)
 }
 
@@ -199,18 +200,22 @@ pub fn[T] Agent::add_tool(
 
 ///|
 pub async fn Agent::start(agent : Agent) -> Unit {
-  agent.emit(ConversationStart, EventContext::new())
-  while true {
-    let response = agent.call()
-    if response.tool_calls is [] {
-      break
+  @async.with_task_group(group => {
+    group.spawn_bg(() => agent.event_target.start(), no_wait=true)
+    group.spawn_bg(() => agent.logger.start(), no_wait=true)
+    agent.emit(PreConversation)
+    while true {
+      let response = agent.call()
+      if response.tool_calls is [] {
+        break
+      }
+      for i in 0..<response.tool_calls.length() {
+        let call = response.tool_calls[i]
+        agent.add_message(agent.execute_tool(call))
+      }
     }
-    for i in 0..<response.tool_calls.length() {
-      let call = response.tool_calls[i]
-      agent.add_message(agent.execute_tool(call))
-    }
-  }
-  agent.emit(ConversationEnd, EventContext::new())
+    agent.emit(PostConversation)
+  })
 }
 
 ///|
@@ -230,6 +235,10 @@ pub async fn new(
   model : @model.Model,
   rand? : @random.Rand,
   uuid? : @uuid.Generator,
+  logger? : @pino.Logger = @pino.logger(
+    "agent",
+    try! @pino.transport("file:.moonagent/log"),
+  ),
   cwd~ : StringView,
 ) -> Agent {
   let rand = match rand {
@@ -245,6 +254,7 @@ pub async fn new(
     @conversation.Manager::new(uuid~, cwd=path)
   }
   let agent = Agent::{
+    logger,
     rand,
     uuid,
     history: session_manager.new_conversation(name="history"),
@@ -252,7 +262,7 @@ pub async fn new(
     model,
     tools: {},
     queue: [],
-    event_target: @event.Target::new(),
+    event_target: EventTarget::new(),
     token_counter: @token.Counter::new(),
     context_pruner: @context.Pruner::new(
       safe_zone_tokens=model.safe_zone_tokens,
@@ -263,12 +273,47 @@ pub async fn new(
 }
 
 ///|
-async fn Agent::emit(
-  agent : Agent,
-  kind : Event,
-  context : EventContext,
-) -> Unit {
-  agent.event_target.emit(kind, context)
+fn Agent::emit(agent : Agent, event : Event) -> Unit {
+  agent.event_target.emit(event)
+  match event {
+    TokenCounted(token_count) =>
+      agent.logger.info("TokenCounted", { "token_count": token_count.to_json() })
+    ContextPruned(origin_token_count~, pruned_token_count~) =>
+      agent.logger.info("ContextPruned", {
+        "origin_token_count": origin_token_count.to_json(),
+        "pruned_token_count": pruned_token_count.to_json(),
+      })
+    PreToolCall(tool_call) =>
+      agent.logger.info("PreToolCall", {
+        "name": tool_call.function.name.to_json(),
+        "args": tool_call.function.arguments.to_json(),
+      })
+    PostToolCall(tool_call, result~, rendered~) =>
+      match result {
+        Ok(output) =>
+          agent.logger.info("PostToolCall", {
+            "name": tool_call.function.name.to_json(),
+            "output": output.to_json(),
+            "text": rendered.to_json(),
+          })
+        Error(error, output) =>
+          agent.logger.info("PostToolCall", {
+            "name": tool_call.function.name.to_json(),
+            "output": output,
+            "error": error.to_json(),
+            "text": rendered.to_json(),
+          })
+      }
+    PreConversation => agent.logger.info("PreConversation", {})
+    PostConversation => agent.logger.info("PostConversation", {})
+    MessageAdded(message) =>
+      agent.logger.info("MessageAdded", { "message": message.to_json() })
+    RequestCompleted(usage~, message~) =>
+      agent.logger.info("RequestCompleted", {
+        "usage": usage.to_json(),
+        "message": message.to_json(),
+      })
+  }
 }
 
 ///|
@@ -277,14 +322,9 @@ async fn Agent::emit(
 /// Parameters:
 ///
 /// * `agent` : The agent to add the event listener to.
-/// * `kind` : The type of event to listen for.
 /// * `f` : The asynchronous callback function to execute when the event is
-///   triggered. The function receives an `EventContext` containing relevant
+///   triggered. The function receives an `Event` containing relevant
 ///   event data.
-pub fn Agent::add_listener(
-  agent : Agent,
-  kind : Event,
-  f : async (EventContext) -> Unit,
-) -> Unit {
-  agent.event_target.add_listener(kind, f)
+pub fn Agent::add_listener(agent : Agent, f : async (Event) -> Unit) -> Unit {
+  agent.event_target.add_listener(f)
 }

--- a/agent/moon.pkg.json
+++ b/agent/moon.pkg.json
@@ -3,13 +3,15 @@
     "moonbitlang/maria/model",
     "moonbitlang/maria/tool",
     "moonbitlang/maria/openai",
-    "moonbitlang/maria/internal/event",
     "moonbitlang/maria/internal/token",
     "moonbitlang/maria/internal/cache",
     "moonbitlang/maria/context",
     "moonbitlang/maria/internal/conversation",
     "moonbitlang/maria/internal/path",
     "moonbitlang/maria/internal/rand",
-    "moonbitlang/maria/internal/uuid"
+    "moonbitlang/maria/internal/uuid",
+    "moonbitlang/async/aqueue",
+    "moonbitlang/async",
+    "moonbitlang/maria/internal/pino"
   ]
 }

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/maria/agent"
 
 import(
   "moonbitlang/core/random"
+  "moonbitlang/maria/internal/pino"
   "moonbitlang/maria/internal/uuid"
   "moonbitlang/maria/model"
   "moonbitlang/maria/openai"
@@ -10,7 +11,7 @@ import(
 )
 
 // Values
-async fn new(@model.Model, rand? : @random.Rand, uuid? : @uuid.Generator, cwd~ : StringView) -> Agent
+async fn new(@model.Model, rand? : @random.Rand, uuid? : @uuid.Generator, logger? : @pino.Logger, cwd~ : StringView) -> Agent
 
 // Errors
 
@@ -22,39 +23,22 @@ pub struct Agent {
   model : @model.Model
   // private fields
 }
-fn Agent::add_listener(Self, Event, async (EventContext) -> Unit) -> Unit
+fn Agent::add_listener(Self, async (Event) -> Unit) -> Unit
 fn Agent::add_message(Self, @openai.ChatCompletionMessageParam) -> Unit
 fn[T] Agent::add_tool(Self, @tool.Tool[T], T) -> Unit
 fn Agent::close(Self) -> Unit
 async fn Agent::start(Self) -> Unit
 
-pub(all) enum Event {
-  ConversationStart
-  ConversationEnd
-  PreToolCall
-  PostToolCall
-  TokenCounted
-  RequestCompleted
+pub enum Event {
+  PreConversation
+  PostConversation
+  MessageAdded(@openai.ChatCompletionMessageParam)
+  PreToolCall(@openai.ChatCompletionMessageToolCall)
+  PostToolCall(@openai.ChatCompletionMessageToolCall, result~ : @tool.Result, rendered~ : String)
+  TokenCounted(Int)
+  ContextPruned(origin_token_count~ : Int, pruned_token_count~ : Int)
+  RequestCompleted(usage~ : @openai.CompletionUsage?, message~ : @openai.ChatCompletionMessage)
 }
-fn Event::equal(Self, Self) -> Bool // from trait `Eq`
-fn Event::hash(Self) -> Int // from trait `Hash`
-fn Event::hash_combine(Self, Hasher) -> Unit // from trait `Hash`
-#deprecated
-fn Event::op_equal(Self, Self) -> Bool // from trait `Eq`
-impl Eq for Event
-impl Hash for Event
-
-pub struct EventContext {
-  usage : @openai.CompletionUsage?
-  message : @openai.ChatCompletionMessage?
-  origin_token_count : Int?
-  pruned_token_count : Int?
-  tool_call : @openai.ChatCompletionMessageToolCall?
-  tool_call_result : @tool.Result?
-  tool_call_result_text : String?
-}
-fn EventContext::to_json(Self) -> Json // from trait `ToJson`
-impl ToJson for EventContext
 
 // Type aliases
 

--- a/cmd/jsonl2md/main.mbt
+++ b/cmd/jsonl2md/main.mbt
@@ -191,6 +191,21 @@ test "format_log_entry/RequestCompleted" {
     },
   }
   format_log_entry(log_entry, msg_cnt~, md_lines)
+  inspect(
+    md_lines.join("\n"),
+    content=(
+      #|# 1 Assistant: I am fine, thank you!
+      #|
+      #|I am fine, thank you!
+      #|
+      #|## Tool call argument: <get_weather>
+      #|
+      #|<location>
+      #|  New York
+      #|</location>
+      #|
+    ),
+  )
 }
 
 ///|

--- a/main/executor/executor.mbt
+++ b/main/executor/executor.mbt
@@ -7,39 +7,35 @@ async fn @pipe.PipeWrite::writeln(self : @pipe.PipeWrite, str : String) -> Unit 
 pub async fn execute(prompt~ : String, model? : String) -> Unit {
   try {
     let maria = @maria.Maria::new(model?)
-    @async.with_task_group(_ => {
-      maria.agent.add_listener(ConversationStart, _ => {
+    maria.agent.add_listener(event => match event {
+      PreConversation => {
         let response : Json = {
           "method": "maria.agent.conversation_start",
           "params": {},
         }
         @pipe.stdout.writeln(response.stringify())
-      })
-      maria.agent.add_listener(RequestCompleted, context => {
-        guard context.usage is Some(usage) else { return }
-        guard context.message is Some(message) else { return }
+      }
+      RequestCompleted(usage~, message~) => {
         let response : Json = {
           "method": "maria.agent.request_completed",
           "params": { "usage": usage.to_json(), "message": message.to_json() },
         }
         @pipe.stdout.writeln(response.stringify())
-      })
-      maria.agent.add_listener(PostToolCall, context => {
-        guard context.tool_call is Some(tool_call) else { return }
-        guard context.tool_call_result is Some(json) else { return }
-        guard context.tool_call_result_text is Some(text) else { return }
+      }
+      PostToolCall(tool_call, result~, rendered~) => {
         let response : Json = {
           "method": "maria.agent.post_tool_call",
           "params": {
             "tool_call": tool_call.to_json(),
-            "json": json.to_json(),
-            "text": text.to_json(),
+            "json": result.to_json(),
+            "text": rendered.to_json(),
           },
         }
         @pipe.stdout.writeln(response.stringify())
-      })
-      maria.start(prompt)
+      }
+      _ => ()
     })
+    maria.start(prompt)
   } catch {
     @io.ReaderClosed => ()
     error => {

--- a/main/executor/moon.pkg.json
+++ b/main/executor/moon.pkg.json
@@ -3,7 +3,6 @@
     "moonbitlang/async/pipe",
     "moonbitlang/maria/agent",
     "moonbitlang/maria/openai",
-    "moonbitlang/async",
     "moonbitlang/async/io",
     "moonbitlang/maria",
     "moonbitlang/maria/tool"

--- a/main/interactive/interactive.mbt
+++ b/main/interactive/interactive.mbt
@@ -2,27 +2,26 @@
 pub async fn interactive(prompt? : String, model? : String) -> Unit {
   @async.with_task_group(group => {
     let maria = @maria.Maria::new(model?)
-    maria.agent.add_listener(RequestCompleted, context => {
-      guard context.message is Some(message) && message.content is Some(content) else {
-        return
+    maria.agent.add_listener(event => match event {
+      RequestCompleted(message~, ..) => {
+        guard message.content is Some(content) else { return }
+        println(content)
       }
-      println(content)
-    })
-    maria.agent.add_listener(PreToolCall, context => {
-      guard context.tool_call is Some(tool_call) else { return }
-      try {
-        let arguments = @json.parse(tool_call.function.arguments)
-        println("% \{tool_call.function.name} \{arguments.stringify(indent=2)}")
-      } catch {
-        _ =>
+      PreToolCall(tool_call) =>
+        try {
+          let arguments = @json.parse(tool_call.function.arguments)
           println(
-            "% \{tool_call.function.name}\n  \{tool_call.function.arguments}",
+            "% \{tool_call.function.name} \{arguments.stringify(indent=2)}",
           )
-      }
-    })
-    maria.agent.add_listener(PostToolCall, context => {
-      guard context.tool_call_result_text is Some(text) else { return }
-      text.split("\n").each(text => println("> \{text}"))
+        } catch {
+          _ =>
+            println(
+              "% \{tool_call.function.name}\n  \{tool_call.function.arguments}",
+            )
+        }
+      PostToolCall(_, rendered~, ..) =>
+        rendered.split("\n").each(text => println("> \{text}"))
+      _ => ()
     })
     if prompt is Some(prompt) {
       maria.start(prompt)

--- a/maria.mbt
+++ b/maria.mbt
@@ -1,5 +1,5 @@
 ///|
-pub(all) struct Maria {
+pub struct Maria {
   logger : @pino.Logger
   agent : @agent.Agent
 }
@@ -25,73 +25,50 @@ pub async fn Maria::new(
   guard @model.load_model(home~, cwd~, model?) is Some(model) else {
     raise ModelNotConfigured
   }
-  let agent = @agent.new(model, cwd~)
-  agent.add_listener(TokenCounted, context => {
-    guard context
-      is {
-        origin_token_count: Some(origin_token_count),
-        pruned_token_count: Some(pruned_token_count),
-        ..,
-      } else {
-      return
-    }
-    logger.info("TokenCounted", { "token_count": origin_token_count.to_json() })
-    if origin_token_count != pruned_token_count {
-      logger.info("ContextPruned", {
-        "origin_token_count": origin_token_count.to_json(),
-        "pruned_token_count": pruned_token_count.to_json(),
+  let agent = @agent.new(model, logger~, cwd~)
+  agent.add_listener(event => match event {
+    TokenCounted(token_count) =>
+      logger.info("TokenCounted", { "token_count": token_count.to_json() })
+    RequestCompleted(usage~, message~) =>
+      logger.info("RequestCompleted", {
+        "usage": usage.to_json(),
+        "message": message.to_json(),
       })
-    }
-  })
-  agent.add_listener(RequestCompleted, context => {
-    guard context.usage is Some(usage) else { return }
-    guard context.message is Some(message) else { return }
-    logger.info("RequestCompleted", {
-      "usage": usage.to_json(),
-      "message": message.to_json(),
-    })
-  })
-  agent.add_listener(PreToolCall, context => {
-    guard context.tool_call is Some(tool_call) else { return }
-    try {
-      let args = @json.parse(tool_call.function.arguments)
-      logger.info("PreToolCall", {
-        "name": tool_call.function.name.to_json(),
-        "args": args,
-      })
-    } catch {
-      error =>
-        logger.error("PreToolCall", {
+    PreToolCall(tool_call) =>
+      try {
+        let args = @json.parse(tool_call.function.arguments)
+        logger.info("PreToolCall", {
           "name": tool_call.function.name.to_json(),
-          "args": tool_call.function.arguments.to_json(),
-          "error": error.to_json(),
+          "args": args,
         })
-    }
-  })
-  agent.add_listener(PostToolCall, context => {
-    guard context.tool_call is Some(tool_call) else { return }
-    guard context.tool_call_result is Some(result) else { return }
-    guard context.tool_call_result_text is Some(text) else { return }
-    match result {
-      Error(error, output) => {
-        logger.info("PostToolCall", {
-          "name": tool_call.function.name.to_json(),
-          "output": output,
-          "error": error.to_json(),
-          "text": text.to_json(),
-        })
-        logger.error("Tool error", { "error": error.to_json() })
+      } catch {
+        error =>
+          logger.info("PreToolCall", {
+            "name": tool_call.function.name.to_json(),
+            "args": tool_call.function.arguments.to_json(),
+            "error": error.to_json(),
+          })
       }
-      Ok(output) =>
-        logger.info("PostToolCall", {
-          "name": tool_call.function.name.to_json(),
-          "output": output,
-          "text": text.to_json(),
-        })
-    }
+    PostToolCall(tool_call, result~, rendered~) =>
+      match result {
+        Ok(output) =>
+          logger.info("PostToolCall", {
+            "name": tool_call.function.name.to_json(),
+            "output": output.to_json(),
+            "text": rendered.to_json(),
+          })
+        Error(error, output) =>
+          logger.info("PostToolCall", {
+            "name": tool_call.function.name.to_json(),
+            "output": output,
+            "error": error.to_json(),
+            "text": rendered.to_json(),
+          })
+      }
+    PreConversation => logger.info("PreConversation", {})
+    PostConversation => logger.info("PostConversation", {})
+    _ => ()
   })
-  agent.add_listener(ConversationStart, _ => logger.info("PreConversation", {}))
-  agent.add_listener(ConversationEnd, _ => logger.info("PostConversation", {}))
   agent.add_tool(
     @execute_command.execute_command,
     @job.Manager::new(cwd=agent.cwd),
@@ -119,12 +96,7 @@ pub fn Maria::close(self : Maria) -> Unit {
 
 ///|
 pub async fn Maria::start(self : Maria, prompt : String) -> Unit {
-  @async.with_task_group(group => {
-    group.spawn_bg(() => self.logger.start(), no_wait=true)
-    let user_message = @openai.user_message(content=prompt)
-    // TODO: move to event system
-    self.logger.info("MessageAdded", { "message": user_message.to_json() })
-    self.agent.add_message(user_message)
-    self.agent.start()
-  })
+  let user_message = @openai.user_message(content=prompt)
+  self.agent.add_message(user_message)
+  self.agent.start()
 }

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -16,7 +16,6 @@
     "moonbitlang/maria/tools/todo_write",
     "moonbitlang/maria/tools/search_files",
     "moonbitlang/maria/prompt",
-    "moonbitlang/maria/job",
-    "moonbitlang/async"
+    "moonbitlang/maria/job"
   ]
 }

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -12,7 +12,7 @@ import(
 pub suberror ModelNotConfigured
 
 // Types and methods
-pub(all) struct Maria {
+pub struct Maria {
   logger : @pino.Logger
   agent : @agent.Agent
 }

--- a/tools/search_files/moon.pkg.json
+++ b/tools/search_files/moon.pkg.json
@@ -14,7 +14,7 @@
     "moonbitlang/maria/agent",
     "moonbitlang/maria/model",
     "moonbitlang/maria/openai",
-    "moonbitlang/maria/internal/pino",
-    "moonbitlang/maria/tools/write_to_file"
+    "moonbitlang/maria/tools/write_to_file",
+    "moonbitlang/maria/internal/pino"
   ]
 }

--- a/tools/search_files/tool_test.mbt
+++ b/tools/search_files/tool_test.mbt
@@ -68,10 +68,15 @@ async test "search_files/agentic" (t : @test.T) {
     let file_manager = @file.manager(cwd=taco.cwd.path())
     agent.add_tool(@write_to_file.write_to_file, file_manager)
     agent.add_tool(@search_files.search_files, taco.cwd.path())
-    agent.add_listener(PostToolCall, (event : @agent.EventContext) => taco.logger.info(
-      "",
-      event.to_json().as_object().unwrap_or({}),
-    ))
+    agent.add_listener(event => match event {
+      PostToolCall(tool_call, result~, rendered~) =>
+        taco.logger.info("PostToolCall", {
+          "tool_call": tool_call.to_json(),
+          "tool_call_result": result.to_json(),
+          "tool_call_result_text": rendered.to_json(),
+        })
+      _ => ()
+    })
     agent.add_message(
       @openai.user_message(
         content=(

--- a/tools/write_to_file/write_to_file_test.mbt
+++ b/tools/write_to_file/write_to_file_test.mbt
@@ -130,10 +130,15 @@ async test "write_to_file/agentic" (t : @test.T) {
       safe_zone_tokens=200000,
     )
     let agent = @agent.new(model, cwd=taco.cwd.path())
-    agent.add_listener(PostToolCall, (event : @agent.EventContext) => taco.logger.info(
-      "",
-      event.to_json().as_object().unwrap_or({}),
-    ))
+    agent.add_listener(event => match event {
+      PostToolCall(tool_call, result~, rendered~) =>
+        taco.logger.info("PostToolCall", {
+          "name": tool_call.function.name.to_json(),
+          "output": result.to_json(),
+          "text": rendered.to_json(),
+        })
+      _ => ()
+    })
     agent.add_tool(@write_to_file.write_to_file, manager)
     agent.add_message(
       @openai.user_message(


### PR DESCRIPTION
This PR refactored the event system of agent. By combining Event with EventContext using a uniformed `enum Event`, this refactorization makes user of maria can access to delivered event in a more "safe" way, as in old implementation one would need to test for nullablity of all fields in `EventContext` before reading them out. And it is not obvious to the users which field is non-nullable for a event.

Closes #129