### PR TITLE
refactor(append_to_file): improve code structure and type safety

### DIFF
--- a/tools/append_to_file/moon.pkg.json
+++ b/tools/append_to_file/moon.pkg.json
@@ -4,5 +4,5 @@
     "moonbitlang/maria/internal/path",
     "moonbitlang/maria/internal/fs"
   ],
-  "wbtest-import" : ["moonbitlang/async", "moonbitlang/maria/internal/mock"]
+  "test-import" : ["moonbitlang/async", "moonbitlang/maria/internal/mock"]
 }

--- a/tools/append_to_file/pkg.generated.mbti
+++ b/tools/append_to_file/pkg.generated.mbti
@@ -7,6 +7,8 @@ import(
 )
 
 // Values
+fn json_input(content~ : String, path~ : String, separator? : String) -> Json
+
 fn new(String) -> @tool.Tool[Result]
 
 // Errors

--- a/tools/append_to_file/tool.mbt
+++ b/tools/append_to_file/tool.mbt
@@ -1,13 +1,43 @@
 ///|
-priv struct Params {
-  content : String
-  path : String?
-  separator : String?
-} derive(ToJson, @json.FromJson)
+let schema : Json = {
+  "type": "object",
+  "properties": {
+    "content": {
+      "type": "string",
+      "description": "The content to append to the file.",
+    },
+    "path": {
+      "type": "string",
+      "description": "The path of the file to append to, relative to the current working directory.",
+    },
+    "separator": {
+      "type": "string",
+      "description": "Optional separator to add between existing content and new content (default: newline).",
+      "default": "\n",
+    },
+  },
+  "required": ["path", "content"],
+}
 
 ///|
-fn params(content~ : String, path? : String, separator? : String) -> Params {
+priv struct Params {
+  content : String // required
+  path : String // required
+  separator : String?
+} derive(ToJson, FromJson)
+
+///|
+fn params(content~ : String, path~ : String, separator? : String) -> Params {
   Params::{ content, path, separator }
+}
+
+///|
+pub fn json_input(
+  content~ : String,
+  path~ : String,
+  separator? : String,
+) -> Json {
+  params(content~, path~, separator?).to_json()
 }
 
 ///|
@@ -25,7 +55,7 @@ test {
 ///|
 struct Result {
   path : String
-} derive(@json.FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub impl Show for Result with output(self : Result, logger : &Logger) -> Unit {
@@ -37,43 +67,17 @@ pub fn new(cwd : String) -> @tool.Tool[Result] {
   @tool.tool(
     description="Append content to a file at the specified path. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.",
     name="append_to_file",
-    parameters={
-      "type": "object",
-      "properties": {
-        "content": {
-          "type": "string",
-          "description": "The content to append to the file.",
-        },
-        "path": {
-          "type": "string",
-          "description": "The path of the file to append to, relative to the current working directory.",
-        },
-        "separator": {
-          "type": "string",
-          "description": "Optional separator to add between existing content and new content (default: newline).",
-          "default": "\n",
-        },
-      },
-      "required": ["path", "content"],
-    },
-    @tool.ToolFn(async fn(args) -> @tool.Result[Result] noraise {
-      let args : Params = @json.from_json(args) catch {
+    parameters=schema,
+    async fn(args) -> @tool.Result[Result] noraise {
+      let { path, separator, content } : Params = @json.from_json(args) catch {
         error => return @tool.error("Invalid arguments: \{error}")
       }
-      let path = if args.path is Some(path) {
-        if @path.is_absolute(path) {
-          path
-        } else {
-          @path.join(cwd, path)
-        }
+      let path = if @path.is_absolute(path) {
+        path
       } else {
-        return @tool.error("Missing 'path' argument")
+        @path.join(cwd, path)
       }
-      let separator = if args.separator is Some(separator) {
-        separator
-      } else {
-        "\n"
-      }
+      let separator = separator.unwrap_or("\n")
       let content_to_append = if (@fs.exists(path) catch {
           error =>
             return @tool.error("Failed to check if file exists: \{error}")
@@ -82,18 +86,18 @@ pub fn new(cwd : String) -> @tool.Tool[Result] {
           error => return @tool.error("Failed to read existing file: \{error}")
         }
         if existing_content.is_empty() {
-          args.content
+          content
         } else {
-          existing_content + separator + args.content
+          existing_content + separator + content
         }
       } else {
-        args.content
+        content
       }
       let _ = @fs.write_to_file(path, content_to_append) catch {
         error => return @tool.error("Failed to write to file: \{error}")
       }
       let result = Result::{ path, }
       @tool.ok(result)
-    }),
+    },
   )
 }

--- a/tools/append_to_file/tool_test.mbt
+++ b/tools/append_to_file/tool_test.mbt
@@ -7,9 +7,9 @@ let original =
 async test "append_to_file" (t : @test.T) {
   @mock.run(t, taco => {
     @fs.write_to_file(@path.join(taco.cwd.path(), "file.txt"), original)
-    let args = params(path="file.txt", content="Line 3", separator="\n")
+    let args = json_input(path="file.txt", content="Line 3", separator="\n")
     let tool = new(taco.cwd.path())
-    let result = tool.call(args.to_json())
+    let result = tool.call(args)
     @json.inspect(taco.json(result.output()), content={
       "path": "(mock:cwd)/file.txt",
     })


### PR DESCRIPTION
This PR refactors the `append_to_file` tool to improve code organization and type safety.

## Changes

- **Schema extraction**: Moved JSON schema to a top-level constant for better organization and reusability
- **Type safety**: Made `path` parameter required (non-optional) in `Params` struct to match the schema's required fields
- **API improvement**: Added public `json_input` helper function for easier test input creation
- **Test migration**: Moved from whitebox test (`_wbtest.mbt`) to blackbox test (`_test.mbt`), which properly tests the public API
- **Package config**: Updated from `wbtest-import` to `test-import` to match the test type change
- **Code simplification**: Cleaned up implementation using destructuring and `unwrap_or`
- **Consistency**: Standardized `FromJson` derive usage

## Testing

All tests pass successfully:
```
Total tests: 2, passed: 2, failed: 0.
```

## Interface Changes

The public interface now includes the `json_input` helper function (visible in `.mbti` file), which makes it easier to construct tool inputs for testing.