### PR TITLE
refactor(check_moonbit_project): improve code structure and API

### DIFF
--- a/internal/mock/taco.mbt
+++ b/internal/mock/taco.mbt
@@ -129,14 +129,14 @@ impl Filterable for Json with filter(self : Filter, value : Json) -> Json {
 ///|
 /// Serializes a value to JSON while masking sensitive fields with the current filter.
 pub fn[T : ToJson] Context::json(self : Context, value : T) -> Json {
-  Filterable::filter(self.filter, ToJson::to_json(value))
+  Filterable::filter(self.filter, value.to_json())
 }
 
 ///|
 /// Formats a value into a filtered string suited for deterministic snapshots.
 #alias(text)
 pub fn[T : Show] Context::show(self : Context, value : T) -> String {
-  Filterable::filter(self.filter, Show::to_string(value))
+  Filterable::filter(self.filter, value.to_string())
 }
 
 ///|

--- a/tools/check_moonbit_project/moon.pkg.json
+++ b/tools/check_moonbit_project/moon.pkg.json
@@ -4,7 +4,7 @@
     "moonbitlang/maria/internal/moon",
     "moonbitlang/maria/internal/path"
   ],
-  "wbtest-import": [
+  "test-import": [
     "moonbitlang/async",
     "moonbitlang/maria/internal/mock",
     "moonbitlang/maria/internal/fs"

--- a/tools/check_moonbit_project/pkg.generated.mbti
+++ b/tools/check_moonbit_project/pkg.generated.mbti
@@ -8,6 +8,8 @@ import(
 )
 
 // Values
+fn input_json(diagnostic_limit? : Int, patch_code? : String, patch_file_name? : String, project_path~ : String) -> Json
+
 fn new(String) -> @tool.Tool[CheckMoonbitProjectResult]
 
 // Errors

--- a/tools/check_moonbit_project/tool.mbt
+++ b/tools/check_moonbit_project/tool.mbt
@@ -13,12 +13,17 @@ fn params(
   patch_file_name? : String,
   project_path~ : String,
 ) -> CheckMoonbitProjectParams {
-  CheckMoonbitProjectParams::{
-    diagnostic_limit,
-    patch_code,
-    patch_file_name,
-    project_path,
-  }
+  { diagnostic_limit, patch_code, patch_file_name, project_path }
+}
+
+///|
+pub fn input_json(
+  diagnostic_limit? : Int,
+  patch_code? : String,
+  patch_file_name? : String,
+  project_path~ : String,
+) -> Json {
+  params(diagnostic_limit?, patch_code?, patch_file_name?, project_path~).to_json()
 }
 
 ///|
@@ -55,39 +60,40 @@ pub impl Show for CheckMoonbitProjectResult with output(
 }
 
 ///|
+let schema : Json = {
+  "type": "object",
+  "properties": {
+    "diagnostic_limit": {
+      "type": "integer",
+      "description": "The maximum number of diagnostics to return. Default is 10.",
+      "default": 10,
+    },
+    "patch_code": {
+      "type": "string",
+      "description": "A code snippet to check as if it were appended to the file at 'patch_file'.",
+      "default": "",
+    },
+    "patch_file_name": {
+      "type": "string",
+      "description": "The file path to check the 'patch_code' against. If not provided, the code will be checked in isolation.",
+      "default": "",
+    },
+    "project_path": {
+      "type": "string",
+      "description": "The path to the MoonBit project to check. Defaults to the current working directory.",
+      "default": ".",
+    },
+  },
+  "required": ["project_path"],
+}
+
+///|
 pub fn new(cwd : String) -> @tool.Tool[CheckMoonbitProjectResult] {
   @tool.tool(
     description="Call MoonBit toolchain to check current MoonBit project, and report any errors. Optionally, you can provide a code snippet and a file path to check the code as if it were appended to that file.",
     name="check_moonbit_project",
-    parameters={
-      "type": "object",
-      "properties": {
-        "diagnostic_limit": {
-          "type": "integer",
-          "description": "The maximum number of diagnostics to return. Default is 10.",
-          "default": 10,
-        },
-        "patch_code": {
-          "type": "string",
-          "description": "A code snippet to check as if it were appended to the file at 'patch_file'.",
-          "default": "",
-        },
-        "patch_file_name": {
-          "type": "string",
-          "description": "The file path to check the 'patch_code' against. If not provided, the code will be checked in isolation.",
-          "default": "",
-        },
-        "project_path": {
-          "type": "string",
-          "description": "The path to the MoonBit project to check. Defaults to the current working directory.",
-          "default": ".",
-        },
-      },
-      "required": ["project_path"],
-    },
-    @tool.ToolFn(async fn(
-      args,
-    ) -> @tool.Result[CheckMoonbitProjectResult] noraise {
+    parameters=schema,
+    async fn(args) -> @tool.Result[CheckMoonbitProjectResult] noraise {
       let args : CheckMoonbitProjectParams = @json.from_json(args) catch {
         error =>
           return @tool.error(
@@ -149,6 +155,6 @@ pub fn new(cwd : String) -> @tool.Tool[CheckMoonbitProjectResult] {
           "\{rendered_diagnostics}",
         })
       }
-    }),
+    },
   )
 }

--- a/tools/check_moonbit_project/tool_test.mbt
+++ b/tools/check_moonbit_project/tool_test.mbt
@@ -1,20 +1,22 @@
 ///|
 async test "check_moonbit_project" (t : @test.T) {
   @mock.run(t, taco => {
-    @fs.write_to_file(
-      @path.join(taco.cwd.path(), "moon.mod.json"),
-      { "name": "example", "version": "0.1.0" }.to_json().stringify(),
-    )
-    @fs.write_to_file(
-      @path.join(taco.cwd.path(), "moon.pkg.json"),
-      Json::object({}).stringify(),
-    )
-    @fs.write_to_file(
-      @path.join(taco.cwd.path(), "example.mbt"),
-      "///|\nlet x : Int = \"string\"",
-    )
-    let args = params(diagnostic_limit=10, project_path=taco.cwd.path())
-    let result = new(taco.cwd.path()).call(args.to_json())
+    taco.add_files([
+      (
+        "moon.mod.json",
+        { "name": "example", "version": "0.1.0" }.to_json().stringify(),
+      ),
+      ("moon.pkg.json", Json::object({}).stringify()),
+      (
+        "example.mbt",
+        (
+          #|///|
+          #|let x : Int = "string"
+        ),
+      ),
+    ])
+    let args = input_json(diagnostic_limit=10, project_path=taco.cwd.path())
+    let result = new(taco.cwd.path()).call(args)
     @json.inspect(taco.json(result), content=[
       "Ok",
       {
@@ -68,25 +70,38 @@ async test "check_moonbit_project" (t : @test.T) {
 ///|
 async test "check_moonbit_project/patch-insert" (t : @test.T) {
   @mock.run(t, taco => {
-    @fs.write_to_file(
-      @path.join(taco.cwd.path(), "moon.mod.json"),
-      { "name": "example", "version": "0.1.0" }.to_json().stringify(),
-    )
-    @fs.write_to_file(
-      @path.join(taco.cwd.path(), "moon.pkg.json"),
-      Json::object({}).stringify(),
-    )
-    @fs.write_to_file(
-      @path.join(taco.cwd.path(), "example.mbt"),
-      "///|\nlet x : Int = \"string\"\n",
-    )
-    let args = params(
+    taco.add_files([
+      (
+        "moon.mod.json",
+        { "name": "example", "version": "0.1.0" }.to_json().stringify(),
+      ),
+      ("moon.pkg.json", Json::object({}).stringify()),
+      (
+        "example.mbt",
+        (
+          #|///|
+          #|let x : Int = "string"
+          #|
+        ),
+      ),
+    ])
+    let args = input_json(
       diagnostic_limit=10,
       project_path=taco.cwd.path(),
       patch_code="let y : String = 42",
       patch_file_name="example.mbt",
     )
-    let result = new(taco.cwd.path()).call(args.to_json())
+    let result = new(taco.cwd.path()).call(args)
+
+    // Note we don't really change the file
+    inspect(
+      @fs.read_file(@path.join(taco.cwd.path(), "example.mbt")),
+      content=(
+        #|///|
+        #|let x : Int = "string"
+        #|
+      ),
+    )
     @json.inspect(taco.json(result), content=[
       "Ok",
       {


### PR DESCRIPTION
This PR refactors the `check_moonbit_project` tool to improve code organization and provide a better public API.

## Changes

### Main Tool Refactoring
- **Schema extraction**: Moved JSON schema to a top-level constant for better organization and reusability
- **API improvement**: Added public `input_json` helper function for easier test input creation
- **Code simplification**: 
  - Used struct shorthand syntax in `params` constructor
  - Removed `ToolFn` wrapper for cleaner async function syntax
  
### Test Migration
- **Whitebox to blackbox**: Migrated from whitebox test (`_wbtest.mbt`) to blackbox test (`_test.mbt`)
- **Better test setup**: Updated tests to use `taco.add_files()` with multi-line strings for better readability
- **Using new API**: Tests now use the `input_json` helper instead of `params().to_json()`
- **Added documentation**: Added helpful comment in patch-insert test clarifying that the file is not actually modified
- **Package config**: Updated from `wbtest-import` to `test-import`

### Additional Improvements
- **Mock utility cleanup**: Simplified trait method calls in `internal/mock/taco.mbt` (using `value.to_json()` instead of `ToJson::to_json(value)`)

## Testing

All tests pass successfully:
```
Total tests: 3, passed: 3, failed: 0.
```

## Interface Changes

The public interface now includes the `input_json` helper function (visible in `.mbti` file):
```moonbit
fn input_json(diagnostic_limit? : Int, patch_code? : String, patch_file_name? : String, project_path~ : String) -> Json
```

This makes it easier to construct tool inputs for testing and matches the pattern established in other tool refactorings.