### PR TITLE
feat(meta_write_to_file): use child logger

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -4,7 +4,7 @@ pub struct Agent {
   uuid : @uuid.Generator
   cwd : String
   model : @model.Model
-  priv logger : @pino.Logger
+  logger : @pino.Logger
   priv tools : Map[String, @tool.AgentTool]
   priv history : @conversation.Conversation
   priv mut queue : Array[@openai.ChatCompletionMessageParam]

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub struct Agent {
   uuid : @uuid.Generator
   cwd : String
   model : @model.Model
+  logger : @pino.Logger
   // private fields
 }
 fn Agent::add_listener(Self, async (Event) -> Unit) -> Unit

--- a/internal/pino/logger.mbt
+++ b/internal/pino/logger.mbt
@@ -1,6 +1,6 @@
 ///|
 struct Logger {
-  tag : String
+  properties : Map[String, Json]
   level : Level
   transport : Transport
 }
@@ -11,7 +11,7 @@ pub fn logger(
   level? : Level = Info,
   transport : Transport,
 ) -> Logger {
-  Logger::{ tag, level, transport }
+  Logger::{ properties: { "tag": tag.to_json() }, level, transport }
 }
 
 ///|
@@ -41,8 +41,8 @@ pub async fn Logger::log(
   }
   let time_ms = @async.now()
   object["time"] = Json::number(time_ms.to_double(), repr=time_ms.to_string())
-  if self.tag != "" {
-    object["tag"] = self.tag.to_json()
+  for k, v in self.properties {
+    object[k] = v
   }
   for k, v in content {
     object[k] = v
@@ -87,6 +87,17 @@ pub async fn Logger::debug(
 }
 
 ///|
-pub fn Logger::child(self : Logger, tag : String) -> Logger {
-  Logger::{ tag, level: self.level, transport: self.transport }
+pub fn Logger::child(self : Logger, properties : Map[String, Json]) -> Logger {
+  let child_properties = {}
+  for k, v in self.properties {
+    child_properties[k] = v
+  }
+  for k, v in properties {
+    child_properties[k] = v
+  }
+  Logger::{
+    properties: child_properties,
+    level: self.level,
+    transport: self.transport,
+  }
 }

--- a/internal/pino/pkg.generated.mbti
+++ b/internal/pino/pkg.generated.mbti
@@ -30,7 +30,7 @@ fn Level::to_string(Self) -> String // from trait `Show`
 impl Show for Level
 
 type Logger
-fn Logger::child(Self, String) -> Self
+fn Logger::child(Self, Map[String, Json]) -> Self
 fn Logger::close(Self) -> Unit
 async fn Logger::debug(Self, StringView, Map[String, Json]) -> Unit
 async fn Logger::error(Self, StringView, Map[String, Json]) -> Unit

--- a/tools/meta_write_to_file/moon.pkg.json
+++ b/tools/meta_write_to_file/moon.pkg.json
@@ -8,7 +8,9 @@
     "moonbitlang/maria/openai",
     "moonbitlang/maria/internal/moon",
     "moonbitlang/async",
-    "moonbitlang/maria/internal/git"
+    "moonbitlang/maria/internal/git",
+    "moonbitlang/maria/internal/pino",
+    "moonbitlang/maria/internal/uuid"
   ],
   "test-import": [
     "moonbitlang/maria/internal/mock",

--- a/tools/meta_write_to_file/tool.mbt
+++ b/tools/meta_write_to_file/tool.mbt
@@ -225,7 +225,16 @@ fn build_fixing_user_message(
 async fn fix_syntax_errors(ctx : FixingContext) -> String? {
   try {
     // Create sub-agent
-    let subagent = @agent.new(ctx.parent_agent.model, cwd=ctx.cwd)
+    let subagent = @agent.new(
+      ctx.parent_agent.model,
+      logger=ctx.parent_agent.logger.child({
+        "tool": {
+          "name": "meta_write_to_file",
+          "id": ctx.parent_agent.uuid.v4().to_json(),
+        },
+      }),
+      cwd=ctx.cwd,
+    )
 
     // Add tools using factory functions
     subagent.add_tools([

--- a/tools/meta_write_to_file/tool_test.mbt
+++ b/tools/meta_write_to_file/tool_test.mbt
@@ -19,7 +19,7 @@ async test "meta_write_to_file/no-op-if-no-syntax-error" (t : @test.T) {
       content=Json::object({ "is-main": true }).stringify(indent=2),
     )
     let main_mbt_file = mock.add_file("main.mbt")
-    let agent = @agent.new(model, cwd=mock.cwd.path())
+    let agent = @agent.new(model, logger=mock.logger, cwd=mock.cwd.path())
     let file_manager = @file.manager(cwd=mock.cwd.path())
     agent.add_tools([
       @replace_in_file.new(file_manager).to_agent_tool(),
@@ -108,7 +108,7 @@ async test "meta_write_to_file/fix-syntax-error" (t : @test.T) {
       content=Json::object({ "is-main": true }).stringify(indent=2),
     )
     let main_mbt_file = mock.add_file("main.mbt")
-    let agent = @agent.new(model, cwd=mock.cwd.path())
+    let agent = @agent.new(model, logger=mock.logger, cwd=mock.cwd.path())
     let file_manager = @file.manager(cwd=mock.cwd.path())
     agent.add_tools([
       @replace_in_file.new(file_manager).to_agent_tool(),
@@ -287,7 +287,7 @@ async test "meta_write_to_file/search-replace" (t : @test.T) {
         #|}
       ),
     )
-    let agent = @agent.new(model, cwd=mock.cwd.path())
+    let agent = @agent.new(model, logger=mock.logger, cwd=mock.cwd.path())
     let file_manager = @file.manager(cwd=mock.cwd.path())
     agent.add_tools([
       @replace_in_file.new(file_manager).to_agent_tool(),


### PR DESCRIPTION
Tool messages are recorded with the following format:

```jsonc
{
  "tool": {
    "name": "<tool-name>",
    "id": "<uuid-v4>"
  },
  // ...
}
```