### PR TITLE
Introduce JsonSchema wrapper for tool definitions

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -51,7 +51,11 @@ async fn Agent::call(agent : Agent) -> @openai.ChatCompletionMessage {
   for name, tool in agent.tools {
     let desc = tool.desc()
     tools.push(
-      @openai.tool(name~, description=desc.description, parameters=desc.schema),
+      @openai.tool(
+        name~,
+        description=desc.description,
+        parameters=desc.schema.to_json(),
+      ),
     )
   }
   let staged = agent.queue

--- a/agent/agent_test.mbt
+++ b/agent/agent_test.mbt
@@ -71,14 +71,14 @@ async test "agent/single_tool_call" (t : @test.T) {
     // Track tool calls
     let mut tool_called = false
     let mut tool_name = ""
-    let calculator_schema : Json = {
+    let calculator_schema = @tool.JsonSchema::from_json({
       "type": "object",
       "properties": {
         "a": { "type": "number", "description": "First number" },
         "b": { "type": "number", "description": "Second number" },
       },
       "required": ["a", "b"],
-    }
+    })
 
     // Add a simple calculator tool
     let calculator_tool = @tool.new(
@@ -124,11 +124,11 @@ async test "agent/multiple_tool_calls" (t : @test.T) {
 
     // Track tool calls
     let tool_calls : Array[String] = []
-    let binary_op_schema : Json = {
+    let binary_op_schema = @tool.JsonSchema::from_json({
       "type": "object",
       "properties": { "a": { "type": "number" }, "b": { "type": "number" } },
       "required": ["a", "b"],
-    }
+    })
 
     // Add multiple tools
     let add_tool = @tool.new(
@@ -297,11 +297,11 @@ async test "agent/tool_error_handling" (t : @test.T) {
     let model = claude_haiku_model(api_key)
     let agent = @agent.new(model, cwd=taco.cwd.path())
     let mut error_encountered = false
-    let binary_op_schema : Json = {
+    let binary_op_schema = @tool.JsonSchema::from_json({
       "type": "object",
       "properties": { "a": { "type": "number" }, "b": { "type": "number" } },
       "required": ["a", "b"],
-    }
+    })
 
     // Add a tool that always fails
     let failing_tool = @tool.new(
@@ -349,11 +349,11 @@ async test "agent/batch_tool_registration" (t : @test.T) {
     let api_key = taco.getenv("OPENAI_API_KEY")
     let model = claude_haiku_model(api_key)
     let agent = @agent.new(model, cwd=taco.cwd.path())
-    let empty_schema : Json = {
+    let empty_schema = @tool.JsonSchema::from_json({
       "type": "object",
       "properties": {},
       "required": [],
-    }
+    })
 
     // Create multiple tools
     let tools = [

--- a/tool/jsonschema.mbt
+++ b/tool/jsonschema.mbt
@@ -1,0 +1,13 @@
+///|
+pub(all) struct JsonSchema(Json)
+
+///|
+pub fn JsonSchema::from_json(schema : Json) -> JsonSchema {
+  JsonSchema(schema)
+}
+
+///|
+pub fn JsonSchema::to_json(self : JsonSchema) -> Json {
+  let JsonSchema(schema) = self
+  schema
+}

--- a/tool/pkg.generated.mbti
+++ b/tool/pkg.generated.mbti
@@ -10,19 +10,25 @@ type AgentTool
 async fn AgentTool::call(Self, Json) -> ToolResult[(Json, String)] noraise
 fn AgentTool::desc(Self) -> ToolDesc
 
+pub(all) struct JsonSchema(Json)
+fn JsonSchema::from_json(Json) -> Self
+#deprecated
+fn JsonSchema::inner(Self) -> Json
+fn JsonSchema::to_json(Self) -> Json
+
 pub struct Tool[Output] {
   desc : ToolDesc
   // private fields
 }
 async fn[Output] Tool::call(Self[Output], Json) -> ToolResult[Output] noraise
 #as_free_fn
-fn[Output] Tool::new(description~ : String, name~ : String, schema~ : Json, ToolFn[Output]) -> Self[Output]
+fn[Output] Tool::new(description~ : String, name~ : String, schema~ : JsonSchema, ToolFn[Output]) -> Self[Output]
 fn[Output : ToJson + Show] Tool::to_agent_tool(Self[Output]) -> AgentTool
 
 pub struct ToolDesc {
   description : String
   name : String
-  schema : Json
+  schema : JsonSchema
 }
 
 pub(all) struct ToolFn[Output](async (Json) -> ToolResult[Output] noraise)

--- a/tool/tool.mbt
+++ b/tool/tool.mbt
@@ -2,7 +2,7 @@
 pub struct ToolDesc {
   description : String
   name : String
-  schema : Json
+  schema : JsonSchema
 }
 
 ///|
@@ -56,7 +56,7 @@ pub fn[Output] ToolResult::error(
 pub fn[Output] Tool::new(
   description~ : String,
   name~ : String,
-  schema~ : Json,
+  schema~ : JsonSchema,
   f : ToolFn[Output],
 ) -> Tool[Output] {
   Tool::{ desc: { description, name, schema }, f }

--- a/tools/check_moonbit_project/tool.mbt
+++ b/tools/check_moonbit_project/tool.mbt
@@ -60,7 +60,7 @@ pub impl Show for CheckMoonbitProjectResult with output(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "diagnostic_limit": {
@@ -85,7 +85,7 @@ let schema : Json = {
     },
   },
   "required": ["project_path"],
-}
+})
 
 ///|
 pub fn new(cwd : String) -> @tool.Tool[CheckMoonbitProjectResult] {

--- a/tools/execute_command/tool.mbt
+++ b/tools/execute_command/tool.mbt
@@ -54,7 +54,7 @@ pub impl Show for CommandResult with output(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "command": {
@@ -78,7 +78,7 @@ let schema : Json = {
     },
   },
   "required": ["command", "timeout"],
-}
+})
 
 ///|
 pub fn new(ctx : @job.Manager) -> @tool.Tool[CommandResult] {

--- a/tools/fix_moonbit_warnings/tool.mbt
+++ b/tools/fix_moonbit_warnings/tool.mbt
@@ -1,5 +1,5 @@
 ///|
-let submit_schema : Json = {
+let submit_schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "properties": {
     "segment": {
       "description": "The fixed MoonBit code segment",
@@ -8,7 +8,7 @@ let submit_schema : Json = {
   },
   "required": ["segment"],
   "type": "object",
-}
+})
 
 ///|
 fn submit_moonbit_segment_new(task : Task) -> @tool.Tool[String] {
@@ -143,7 +143,7 @@ async fn process_segment(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "properties": {
     "description": {
       "description": "A description of the changes to be made to fix the warnings/errors.",
@@ -155,7 +155,7 @@ let schema : Json = {
     },
   },
   "required": ["description", "project_path"],
-}
+})
 
 ///|
 pub fn new(agent : @agent.Agent) -> @tool.Tool[String] {

--- a/tools/get_moonbit_coverage/tool.mbt
+++ b/tools/get_moonbit_coverage/tool.mbt
@@ -49,7 +49,7 @@ async fn execute_get_moonbit_coverage(
 }
 
 ///|
-let json_schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "file": {
@@ -62,14 +62,14 @@ let json_schema : Json = {
     },
   },
   "required": ["project_path"],
-}
+})
 
 ///|
 pub fn new(cwd : String) -> @tool.Tool[CoverageResult] {
   @tool.new(
     description="Get coverage information for a MoonBit source file or project. If a specific file is provided, this tool analyzes that file and returns line-by-line coverage data. If the file is not found, it returns the coverage summary for the entire project.",
     name="get_moonbit_coverage",
-    schema=json_schema,
+    schema~,
     @tool.ToolFn(async fn(args) -> @tool.ToolResult[CoverageResult] noraise {
       let args : Params = @json.from_json(args) catch {
         error => return @tool.error("Invalid arguments: \{error}", error~)

--- a/tools/get_moonbit_mbti/tool.mbt
+++ b/tools/get_moonbit_mbti/tool.mbt
@@ -1,5 +1,5 @@
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "package": {
@@ -8,7 +8,7 @@ let schema : Json = {
     },
   },
   "required": ["package"],
-}
+})
 
 ///|
 pub fn new(cwd : String) -> @tool.Tool[String] {

--- a/tools/list_files/list_files.mbt
+++ b/tools/list_files/list_files.mbt
@@ -95,7 +95,7 @@ async fn execute_list_files(
 }
 
 ///|
-let json_schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "path": {
@@ -104,14 +104,14 @@ let json_schema : Json = {
     },
   },
   "required": ["path"],
-}
+})
 
 ///|
 pub fn new(manager : @file.Manager) -> @tool.Tool[ListFilesResult] {
   @tool.new(
     description="List files in a directory",
     name="list_files",
-    schema=json_schema,
+    schema~,
     @tool.ToolFn(async fn(args) -> @tool.ToolResult[ListFilesResult] noraise {
       guard args is { "path": String(path), .. } else {
         return @tool.error("Error: 'path' parameter is required")

--- a/tools/list_jobs/tool.mbt
+++ b/tools/list_jobs/tool.mbt
@@ -1,5 +1,9 @@
 ///|
-let schema : Json = { "type": "object", "properties": {}, "required": [] }
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
+  "type": "object",
+  "properties": {},
+  "required": [],
+})
 
 ///|
 pub fn new(manager : @job.Manager) -> @tool.Tool[String] {

--- a/tools/meta_write_to_file/tool.mbt
+++ b/tools/meta_write_to_file/tool.mbt
@@ -49,7 +49,7 @@ async fn check_syntax_errors(_file_path : String, cwd : String) -> String {
 
 ///|
 /// Tool for the sub-agent to submit fixed code segments
-let submit_schema : Json = {
+let submit_schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "content": {
@@ -58,7 +58,7 @@ let submit_schema : Json = {
     },
   },
   "required": ["content"],
-}
+})
 
 ///|
 fn submit_fixed_file_new(ctx : FixingContext) -> @tool.Tool[String] {
@@ -94,7 +94,7 @@ fn submit_fixed_file_new(ctx : FixingContext) -> @tool.Tool[String] {
 
 ///|
 /// Tool for the sub-agent to read current file content
-let read_schema : Json = {
+let read_schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "path": {
@@ -103,7 +103,7 @@ let read_schema : Json = {
     },
   },
   "required": ["path"],
-}
+})
 
 ///|
 fn read_current_file_new(ctx : FixingContext) -> @tool.Tool[String] {
@@ -133,7 +133,7 @@ fn read_current_file_new(ctx : FixingContext) -> @tool.Tool[String] {
 
 ///|
 /// Tool for the sub-agent to signal completion
-let completion_schema : Json = {
+let completion_schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "result": {
@@ -142,7 +142,7 @@ let completion_schema : Json = {
     },
   },
   "required": ["result"],
-}
+})
 
 ///|
 fn attempt_completion_new(_ : FixingContext) -> @tool.Tool[String] {
@@ -425,7 +425,7 @@ async fn execute_meta_write_to_file(
 
 ///|
 /// The meta_write_to_file tool definition
-let meta_schema : Json = {
+let meta_schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "path": {
@@ -446,7 +446,7 @@ let meta_schema : Json = {
     },
   },
   "required": ["path", "description"],
-}
+})
 
 ///|
 pub fn new(agent : @agent.Agent) -> @tool.Tool[MetaWriteToFileResult] {

--- a/tools/read_file/read_file.mbt
+++ b/tools/read_file/read_file.mbt
@@ -121,7 +121,7 @@ async fn execute_read_file_tool(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "path": {
@@ -138,7 +138,7 @@ let schema : Json = {
     },
   },
   "required": ["path"],
-}
+})
 
 ///|
 pub fn new(manager : @file.Manager) -> @tool.Tool[ReadFileToolResult] {

--- a/tools/replace_in_file/replace_in_file.mbt
+++ b/tools/replace_in_file/replace_in_file.mbt
@@ -281,7 +281,7 @@ async fn @file.Manager::execute_replace_in_file(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "path": {
@@ -298,7 +298,7 @@ let schema : Json = {
     },
   },
   "required": ["path"],
-}
+})
 
 ///|
 pub fn new(manager : @file.Manager) -> @tool.Tool[WriteResult] {

--- a/tools/search_files/tool.mbt
+++ b/tools/search_files/tool.mbt
@@ -444,7 +444,7 @@ async fn search_files_impl(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "context_lines": {
@@ -472,7 +472,7 @@ let schema : Json = {
     },
   },
   "required": ["path", "regex", "kind"],
-}
+})
 
 ///|
 /// Main search files tool implementation

--- a/tools/todo_read/tool.mbt
+++ b/tools/todo_read/tool.mbt
@@ -76,7 +76,11 @@ pub impl Show for TodoReadResult with output(
 }
 
 ///|
-let schema : Json = { "type": "object", "properties": {}, "required": [] }
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
+  "type": "object",
+  "properties": {},
+  "required": [],
+})
 
 ///|
 pub fn new(list : @todo.List) -> @tool.Tool[TodoReadResult] {

--- a/tools/todo_write/tool.mbt
+++ b/tools/todo_write/tool.mbt
@@ -246,7 +246,7 @@ async fn @todo.List::execute_todo_write(
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "action": {
@@ -275,7 +275,7 @@ let schema : Json = {
     },
   },
   "required": ["action"],
-}
+})
 
 ///|
 /// @param list the todolist is shared globally

--- a/tools/wait_job/tool.mbt
+++ b/tools/wait_job/tool.mbt
@@ -18,7 +18,7 @@ fn truncate_output(output : String, max_output_lines~ : Int) -> String {
 }
 
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "job_id": {
@@ -35,7 +35,7 @@ let schema : Json = {
     },
   },
   "required": ["job_id", "timeout", "max_output_lines"],
-}
+})
 
 ///|
 pub fn new(manager : @job.Manager) -> @tool.Tool[String] {

--- a/tools/write_to_file/write_to_file.mbt
+++ b/tools/write_to_file/write_to_file.mbt
@@ -1,5 +1,5 @@
 ///|
-let schema : Json = {
+let schema : @tool.JsonSchema = @tool.JsonSchema::from_json({
   "type": "object",
   "properties": {
     "content": {
@@ -17,7 +17,7 @@ let schema : Json = {
     },
   },
   "required": ["path", "content"],
-}
+})
 
 ///|
 priv struct Params {


### PR DESCRIPTION
## Summary
- wrap tool schemas in a dedicated JsonSchema type
- update all tool constructors/tests to use the new wrapper
- ensure agent and OpenAI integration serializes schemas correctly

## Testing
- moon check
- moon info
- moon fmt