### PR TITLE
fix(openai): retry on invalid JSON response

### DIFF
--- a/openai/ai.mbt
+++ b/openai/ai.mbt
@@ -22,39 +22,45 @@ pub async fn chat(
   request : ChatCompletionParam,
   logger? : @pino.Logger,
 ) -> ChatCompletion {
-  if logger is Some(logger) {
-    logger.info("RequestSent", {
-      "model": { "name": model.name, "base_url": model.base_url },
-      "request": request.to_json(),
-    })
-  }
-  let (response, response_body) = @async.retry(
+  @async.retry(
     ExponentialDelay(initial=1000, factor=2.0, maximum=16000),
     max_retry=5,
-    () => @http.post("\{model.base_url}/chat/completions", request.to_json(), headers={
-      "Authorization": "Bearer \{model.api_key}",
-      "Content-Type": "application/json",
-      "Connection": "close",
-    }),
+    () => {
+      if logger is Some(logger) {
+        logger.debug("RequestSent", {
+          "model": { "name": model.name, "base_url": model.base_url },
+          "request": request.to_json(),
+        })
+      }
+      let (response, response_body) = @http.post(
+        "\{model.base_url}/chat/completions",
+        request.to_json(),
+        headers={
+          "Authorization": "Bearer \{model.api_key}",
+          "Content-Type": "application/json",
+          "Connection": "close",
+        },
+      )
+      if logger is Some(logger) {
+        logger.debug("ResponseReceived", {
+          "model": { "name": model.name, "base_url": model.base_url },
+          "response_code": response.code.to_json(),
+          "response_body": {
+            let text = response_body.text()
+            if (try? @json.parse(text)) is Ok(json) {
+              json
+            } else {
+              text.to_json()
+            }
+          },
+        })
+      }
+      guard response.code is (200..=299) else {
+        raise HttpError(code=response.code, body=response_body.text())
+      }
+      response_body.json() |> @json.from_json()
+    },
   )
-  if logger is Some(logger) {
-    logger.info("ResponseReceived", {
-      "model": { "name": model.name, "base_url": model.base_url },
-      "response_code": response.code.to_json(),
-      "response_body": {
-        let text = response_body.text()
-        if (try? @json.parse(text)) is Ok(json) {
-          json
-        } else {
-          text.to_json()
-        }
-      },
-    })
-  }
-  guard response.code is (200..=299) else {
-    raise HttpError(code=response.code, body=response_body.text())
-  }
-  response_body.json() |> @json.from_json()
 }
 
 ///|


### PR DESCRIPTION
Some provider on openrouter does not following OpenAI API format strictly, and might causing the @json.from_json() to fail. We put the JSON parsing logic into the retry body so that we can retry if the JSON parsing failed.