### PR TITLE
bump async

### DIFF
--- a/moon.mod.json
+++ b/moon.mod.json
@@ -2,7 +2,7 @@
   "name": "moonbitlang/maria",
   "version": "0.1.0",
   "deps": {
-    "moonbitlang/async": "0.10.3",
+    "moonbitlang/async": "0.10.4",
     "moonbitlang/x": "0.4.34",
     "moonbitlang/regexp": "0.3.1",
     "myfreess/charclass": "0.1.3",

--- a/tools/fix_moonbit_warnings/tool.mbt
+++ b/tools/fix_moonbit_warnings/tool.mbt
@@ -206,12 +206,7 @@ pub fn new(agent : @agent.Agent) -> @tool.Tool[String] {
                   segment.replace(updated)
                   segments_updated += 1
                 }
-              }) catch {
-                error =>
-                  println(
-                    "Warning: Failed to process segment in file \{file.path()}: \{error}",
-                  )
-              }
+              })
             }
             files_updated += 1
           }


### PR DESCRIPTION
cc @lynzrand 
`moon check` and `moon build` reports warnings in a inconsistent way,
moon check reported some warnings while moon build reported other warnings

1. moon check reported the warning: Error: [0023]
     ╭─[ /Users/hongbozhang/git/maria/tools/fix_moonbit_warnings/tool.mbt:197:15 ]
     │
 197 │ ╭─▶               group.spawn_bg(() => {
     ┆ ┆
 209 │ ├─▶               }) catch {
     │ │
     │ ╰────────────────────────────── Error (warning): The body of this try expression never raises any error.
─────╯
2. moon build reported another warning:

WARN Duplicate alias `fs` at "/Users/hongbozhang/git/maria/internal/fs/moon.pkg.json". "test-import" will automatically add "import" and current package as dependency so you don't need to add it manually. If you're test-importing a dependency with the same default alias as your current package, considering give it a different alias than the current package. Violating import: `moonbitlang/async/fs`
Finished. moon: ran 164 tasks, now up to date
