### PR TITLE
test(moon): add enum test case

### DIFF
--- a/internal/moon/fmt_test.mbt
+++ b/internal/moon/fmt_test.mbt
@@ -7,6 +7,27 @@ async test "format_string" {
     (
       #|struct Point {x: Int,y: Int}
     ),
+    (
+      #|enum Color {
+      #|  Red,
+      #|  Green,
+      #|  Blue,
+      #|}
+      #|
+      #|fn Color::to_string(self : Color) -> String {
+      #|  switch self {
+      #|    Red => "red",
+      #|    Green => "green",
+      #|    Blue => "blue",
+      #|  }
+      #|}
+      #|
+      #|fn main() {
+      #|
+      #|  let color : Color = Blue
+      #|  println(color.to_string())
+      #|}
+    ),
     /// TODO: this is not formatted properly
     (
       #|enum Shape { Circle(radius: Int), Square(side: Int) }
@@ -23,6 +44,9 @@ async test "format_string" {
   @json.inspect(format_all, content=[
     { "Ok": "///|\nfn main {\n  println(\"Hello, world!\")\n}\n" },
     { "Ok": "///|\nstruct Point {\n  x : Int\n  y : Int\n}\n" },
+    {
+      "Ok": "enum Color {\n  Red,\n  Green,\n  Blue,\n}\n\nfn Color::to_string(self : Color) -> String {\n  switch self {\n    Red => \"red\",\n    Green => \"green\",\n    Blue => \"blue\",\n  }\n}\n\nfn main() {\n\n  let color : Color = Blue\n  println(color.to_string())\n}\n",
+    },
     { "Ok": "enum Shape { Circle(radius: Int), Square(side: Int) }\n" },
   ])
   // let formatted = @moon.format_string(


### PR DESCRIPTION
@bobzhang 

`moon fmt` fails to format this string because there is no `///|` block-line in this piece of MoonBit code, and `switch self` is a non-recoverable error thus `moonfmt` have to keep the whole original content as is.