### PR TITLE
test(read_multiple_files): add end to end testing

### DIFF
--- a/agent/agent_test.mbt
+++ b/agent/agent_test.mbt
@@ -500,3 +500,85 @@ async test "agent/read_multiple_files" (t : @test.Test) {
     inspect(file_content.contains("Bar"), content="true")
   })
 }
+
+///|
+/// Test agent with read multiple files
+async test "agent/read_multiple_files/specified_ranges" (t : @test.Test) {
+  @mock.run(t, retry=3, taco => {
+    let api_key = taco.getenv("OPENAI_API_KEY")
+    let model = claude_haiku_model(api_key)
+    let agent = @agent.new(model, cwd=taco.cwd.path(), logger=taco.logger)
+
+    // Add file management tools
+    let file_manager = @file.manager(cwd=taco.cwd.path())
+    agent.add_tools([
+      @read_multiple_files.new(file_manager).to_agent_tool(),
+      @replace_in_file.new(file_manager).to_agent_tool(),
+    ])
+
+    // Track if files were created/read
+    let mut multiple_files_read = false
+    agent.add_listener(event => match event {
+      PreToolCall(tool_call) =>
+        match tool_call.function.name {
+          "read_multiple_files" => multiple_files_read = true
+          _ => ()
+        }
+      _ => ()
+    })
+    let args1 : Json = {
+      "files": [
+        { "path": "foo.txt", "start_line": 1, "end_line": 3 },
+        { "path": "bar.txt", "start_line": 2, "end_line": 4 },
+        { "path": "bar.txt" },
+      ],
+    }
+    let args2 : Json = {
+      "files": [{ "path": "foo.txt" }, { "path": "bar.txt" }],
+    }
+    let system_prompt =
+      $| # read_multiple_files 
+      $|
+      $| This tool allows you to read multiple files with specified line ranges(optional) at once 
+      $| 
+      $| read_multiple_files parameters: should be the typescript type `{ files : { path : string; start_line?: number; end_line?: number }[] }`
+      $|
+      $| ## examples 
+      $|
+      $| e.g. \{args1.stringify()}
+      $|
+      $| e.g. \{args2.stringify()}
+      $|
+    agent.add_message(@openai.system_message(content=system_prompt))
+    let _ = taco.add_file(
+      "foo.txt",
+      content=(
+        #|foo.txt:L1 
+        #|foo.txt:L2 
+        #|foo.txt:L3 
+        #|foo.txt:L4 
+        #|foo.txt:L5 
+      ),
+    )
+    let _ = taco.add_file(
+      "bar.txt",
+      content=(
+        #|bar.txt:L1 
+        #|bar.txt:L2 
+        #|bar.txt:L3 
+      ),
+    )
+
+    // Ask agent to create and read a file
+    let content =
+      #| you should concat foo.txt Line 3 - Line 4, and bar.txt Line 3,
+      #| and then write to output.txt
+    agent.add_message(@openai.user_message(content~))
+    agent.start()
+    inspect(multiple_files_read, content="true")
+    // Verify file was actually created
+
+    let file_content = @fs.read_file(@path.join(taco.cwd.path(), "output.txt"))
+    println(file_content)
+  })
+}


### PR DESCRIPTION
we can refine the prompt in the future, make LLM can recognize very common source location format which vscode well support jump in the terminal.

e.g. `main.mbt:594:3-594:8`