### PR TITLE
fix(meta_write_to_file): show syntax errors

### DIFF
--- a/tools/meta_write_to_file/tool.mbt
+++ b/tools/meta_write_to_file/tool.mbt
@@ -299,7 +299,14 @@ async fn execute_meta_write_to_file(
       }
       fix_syntax_errors(fixing_ctx) catch {
         error =>
-          return @tool.error("Failed to fix syntax errors: \{error}", error~)
+          return @tool.error(
+            (
+              $|Failed to fix syntax errors in 5 minutes: \{error}
+              $|
+              $|\{syntax_errors}
+            ),
+            error~,
+          )
       }
 
       // Re-format the file after fixing syntax errors


### PR DESCRIPTION
when fixing failed