### PR TITLE
fix(execute_command): disable background execution

### DIFF
--- a/tools/execute_command/schema.mbt
+++ b/tools/execute_command/schema.mbt
@@ -16,11 +16,12 @@ let schema : @tool.JsonSchema = {
       "description": "The maximum number of output lines to return directly. If the output exceeds this number, it will be truncated and saved to a file.",
       "default": 100,
     },
-    "background": {
-      "type": "boolean",
-      "description": "Whether to run the command in the background (non-blocking). If true, the tool will return immediately after starting the command.",
-      "default": false,
-    },
+    // FIXME: enable background execution when supported
+    // "background": {
+    //   "type": "boolean",
+    //   "description": "Whether to run the command in the background (non-blocking). If true, the tool will return immediately after starting the command.",
+    //   "default": false,
+    // },
   },
   "required": ["command"],
 }

--- a/tools/execute_command/tool.mbt
+++ b/tools/execute_command/tool.mbt
@@ -130,6 +130,12 @@ pub fn new(ctx : @job.Manager) -> @tool.Tool[CommandResult] {
       } else {
         false
       }
+      // FIXME: enable background execution when supported
+      guard background is false else {
+        @tool.error(
+          "Background execution is not supported in this environment.",
+        )
+      }
       if background {
         let job = ctx.spawn(name=command, command~) catch {
           error =>

--- a/tools/execute_command/tool_test.mbt
+++ b/tools/execute_command/tool_test.mbt
@@ -117,6 +117,8 @@ async test "cd" (t : @test.Test) {
 }
 
 ///|
+/// FIXME: enable background execution when supported
+#cfg(false)
 async test "background" (t : @test.Test) {
   @mock.run(t, mock => {
     let manager = @job.Manager::new(cwd=mock.cwd.path())


### PR DESCRIPTION
Currently background execution is useless as it is not possible for model to inspect background task running status - `<list_jobs>`, `<wait_job>` is not enabled.