### PR TITLE
feat(mock): add Directory::add_json_tree for recursive file/directory creation

### DIFF
--- a/internal/mock/mock.mbt
+++ b/internal/mock/mock.mbt
@@ -91,6 +91,18 @@ pub async fn Context::add_directory(self : Context, name : String) -> Directory 
 }
 
 ///|
+/// Recursively adds files and directories from a JSON tree structure to the
+/// mock workspace root.
+///
+/// See `Directory::add_json_tree` for details on the expected JSON structure.
+pub async fn Context::add_json_tree(
+  self : Context,
+  tree : Map[String, Json],
+) -> Unit {
+  self.cwd.add_json_tree(tree)
+}
+
+///|
 struct Filter {
   keywords : Array[(String, String)]
 }
@@ -204,6 +216,48 @@ pub async fn Directory::add_directory(
   let path = @path.join(self.0, name)
   @fs.mkdir(path, permission=0o755)
   Directory(path)
+}
+
+///|
+/// Recursively adds files and directories from a JSON tree structure.
+///
+/// The JSON tree should be an object where:
+/// - String values represent file contents (creates a file with that content)
+/// - Object values represent subdirectories (recursively processed)
+///
+/// Parameters:
+///
+/// * `tree` : A JSON object representing the directory tree to create.
+///
+/// Example:
+///
+/// ```moonbit
+/// directory.add_json_tree({
+///   "file.txt": "content",
+///   "subdir": {
+///     "nested.txt": "nested content"
+///   }
+/// })
+/// ```
+///
+/// Returns `Err` if the JSON structure contains non-string, non-object values.
+pub async fn Directory::add_json_tree(
+  self : Directory,
+  tree : Map[String, Json],
+) -> Unit {
+  for name, value in tree {
+    match value {
+      String(content) => self.add_file(name, content~) |> ignore
+      Object(subtree) => {
+        let subdir = self.add_directory(name)
+        subdir.add_json_tree(subtree)
+      }
+      _ =>
+        fail(
+          "Invalid JSON tree: expected String (file content) or Object (directory), got \{value}",
+        )
+    }
+  }
 }
 
 ///|

--- a/internal/mock/mock_test.mbt
+++ b/internal/mock/mock_test.mbt
@@ -22,3 +22,97 @@ async test "moon_home" (t : @test.Test) {
     content="(mock:env:MOON_HOME)",
   ))
 }
+
+///|
+async test "add_json_tree" (t : @test.Test) {
+  @mock.run(t, mock => {
+    mock.add_json_tree({
+      "file.txt": "hello",
+      "subdir": {
+        "nested.txt": "world",
+        "deep": { "a.txt": "aaa", "b.txt": "bbb" },
+      },
+      "empty_dir": {},
+    })
+    // Verify root file
+    let root_file_path = @path.join(mock.cwd.path(), "file.txt")
+    inspect(@fs.read_file(root_file_path).text(), content="hello")
+    // Verify nested file
+    let nested_file_path = @path.join(
+      @path.join(mock.cwd.path(), "subdir"),
+      "nested.txt",
+    )
+    inspect(@fs.read_file(nested_file_path).text(), content="world")
+    // Verify deeply nested files
+    let deep_dir = @path.join(@path.join(mock.cwd.path(), "subdir"), "deep")
+    let deep_a_path = @path.join(deep_dir, "a.txt")
+    let deep_b_path = @path.join(deep_dir, "b.txt")
+    inspect(@fs.read_file(deep_a_path).text(), content="aaa")
+    inspect(@fs.read_file(deep_b_path).text(), content="bbb")
+    // Verify empty directory exists
+    let empty_dir_path = @path.join(mock.cwd.path(), "empty_dir")
+    inspect(@fs.kind(empty_dir_path) is @fs.FileKind::Directory, content="true")
+  })
+}
+
+///|
+async test "add_json_tree/empty_tree" (t : @test.Test) {
+  @mock.run(t, mock => {
+    // Empty tree should work without errors
+    mock.add_json_tree({})
+    let entries = mock.cwd.list()
+    inspect(entries.length(), content="0")
+  })
+}
+
+///|
+async test "add_json_tree/empty_content" (t : @test.Test) {
+  @mock.run(t, mock => {
+    mock.add_json_tree({ "empty.txt": "" })
+    let file_path = @path.join(mock.cwd.path(), "empty.txt")
+    inspect(@fs.read_file(file_path).text(), content="")
+  })
+}
+
+///|
+async test "add_json_tree/directory_then_add_more" (t : @test.Test) {
+  @mock.run(t, mock => {
+    // First add some structure
+    mock.add_json_tree({ "dir1": { "a.txt": "a" } })
+    // Then add more to the root
+    mock.add_json_tree({ "dir2": { "b.txt": "b" } })
+    // Verify both exist
+    let a_path = @path.join(@path.join(mock.cwd.path(), "dir1"), "a.txt")
+    let b_path = @path.join(@path.join(mock.cwd.path(), "dir2"), "b.txt")
+    inspect(@fs.read_file(a_path).text(), content="a")
+    inspect(@fs.read_file(b_path).text(), content="b")
+  })
+}
+
+///|
+async test "add_json_tree/invalid_value_panics" (t : @test.Test) {
+  @mock.run(t, mock => try {
+    // Number value should cause a panic
+    mock.add_json_tree({ "file.txt": Json::number(42) })
+    fail("Expected panic for invalid JSON value")
+  } catch {
+    _ => () // Expected to fail
+  })
+}
+
+///|
+async test "add_json_tree/special_characters_in_filename" (t : @test.Test) {
+  @mock.run(t, mock => {
+    mock.add_json_tree({
+      "file with spaces.txt": "content1",
+      "file-with-dashes.txt": "content2",
+      "file_with_underscores.txt": "content3",
+    })
+    let p1 = @path.join(mock.cwd.path(), "file with spaces.txt")
+    let p2 = @path.join(mock.cwd.path(), "file-with-dashes.txt")
+    let p3 = @path.join(mock.cwd.path(), "file_with_underscores.txt")
+    inspect(@fs.read_file(p1).text(), content="content1")
+    inspect(@fs.read_file(p2).text(), content="content2")
+    inspect(@fs.read_file(p3).text(), content="content3")
+  })
+}

--- a/internal/mock/pkg.generated.mbti
+++ b/internal/mock/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub struct Context {
 pub async fn Context::add_directory(Self, String) -> Directory
 pub async fn Context::add_file(Self, String, content? : String) -> File
 pub async fn Context::add_files(Self, Map[String, String]) -> Unit
+pub async fn Context::add_json_tree(Self, Map[String, Json]) -> Unit
 pub async fn Context::add_symlink(Self, String, to~ : String) -> Unit
 pub fn Context::getenv(Self, String, allow_empty? : Bool) -> String raise
 pub fn[T : ToJson] Context::json(Self, T) -> Json
@@ -44,6 +45,7 @@ type Directory
 pub async fn Directory::add_directory(Self, String) -> Self
 pub async fn Directory::add_file(Self, String, content? : String) -> File
 pub async fn Directory::add_files(Self, Map[String, String]) -> Unit
+pub async fn Directory::add_json_tree(Self, Map[String, Json]) -> Unit
 pub async fn Directory::list(Self) -> Array[Entry]
 pub fn Directory::path(Self) -> String
 


### PR DESCRIPTION
- Add Directory::add_json_tree and Context::add_json_tree methods
- Support nested JSON structure: strings for files, objects for directories
- Invalid JSON values (numbers, arrays, etc.) cause a panic with clear error
- Add comprehensive tests for the new functionality
- Simplify fix_moonbit_warnings test using add_json_tree