### PR TITLE
docs(prompts): fix todo tool usage barriers

### DIFF
--- a/prompt/prelude.mbt
+++ b/prompt/prelude.mbt
@@ -166,11 +166,16 @@ pub let prelude : String =
   #|   necessary. Each goal should correspond to a distinct step in your
   #|   problem-solving process.
   #|
-  #|4. Before you prepare to modify the code, ALWAYS check if you need to create
-  #|   a todo list using <todo/> to help you handle complex or long task.
-  #|   Utilize the <todo/> tool extensively to organize work and provide
-  #|   visibility into your progress. This is essential for planning and ensures
-  #|   important steps aren't forgotten.
+  #|4. For complex or multi-step tasks, you MUST create a todo list using <todo/>
+  #|   before beginning implementation. This helps you organize work and provide
+  #|   visibility into your progress. Task tracking is essential for planning and
+  #|   ensures important steps aren't forgotten.
+  #|   
+  #|   A task is considered complex if it involves:
+  #|   - 3 or more distinct implementation steps
+  #|   - Multiple files or components to modify
+  #|   - User provides multiple numbered or listed requirements
+  #|   - Coordination between different parts of the codebase
   #|
   #|   a. Break complex work into logical, actionable steps that can be tracked
   #|      and verified. Update task status consistently throughout execution

--- a/prompt/prelude.md
+++ b/prompt/prelude.md
@@ -164,11 +164,16 @@ to follow to accomplish a task:
    necessary. Each goal should correspond to a distinct step in your
    problem-solving process.
 
-4. Before you prepare to modify the code, ALWAYS check if you need to create
-   a todo list using <todo/> to help you handle complex or long task.
-   Utilize the <todo/> tool extensively to organize work and provide
-   visibility into your progress. This is essential for planning and ensures
-   important steps aren't forgotten.
+4. For complex or multi-step tasks, you MUST create a todo list using <todo/>
+   before beginning implementation. This helps you organize work and provide
+   visibility into your progress. Task tracking is essential for planning and
+   ensures important steps aren't forgotten.
+   
+   A task is considered complex if it involves:
+   - 3 or more distinct implementation steps
+   - Multiple files or components to modify
+   - User provides multiple numbered or listed requirements
+   - Coordination between different parts of the codebase
 
    a. Break complex work into logical, actionable steps that can be tracked
       and verified. Update task status consistently throughout execution

--- a/tools/todo/prompt.mbt
+++ b/tools/todo/prompt.mbt
@@ -29,20 +29,18 @@ pub let prompt : String =
   #|
   #|### Writing/Managing Tasks
   #|
-  #|Use write actions (create, add_task, update, mark_progress, mark_completed) proactively in these scenarios, but ONLY AFTER thorough project exploration:
+  #|Use write actions (create, add_task, update, mark_progress, mark_completed) proactively in these scenarios:
   #|
-  #|- **FIRST EXPLORE THE PROJECT**: Always start with project exploration using
-  #|  search_files, execute_command, and AC module searches
   #|- **Complex multi-step tasks**: When a task requires 3 or more distinct steps or
-  #|  actions
+  #|  actions - create the todo list FIRST, then explore as needed for each step
   #|- **Non-trivial and complex tasks**: Tasks that require careful planning or
   #|  multiple operations
   #|- **User explicitly requests todo list**: When the user directly asks you to use
   #|  the todo list
   #|- **User provides multiple tasks**: When users provide a list of things to be
-  #|  done (numbered or comma-separated)
+  #|  done (numbered or comma-separated) - capture these immediately
   #|- **After receiving new instructions**: Immediately capture user requirements as
-  #|  todos, but explore the codebase first
+  #|  high-level todos, then refine as you explore
   #|- **When you start working on a task**: Mark it as in_progress BEFORE beginning
   #|  work (ideally only one task should be in_progress at a time)
   #|- **After completing a task**: Mark it as completed and add any new follow-up
@@ -100,14 +98,16 @@ pub let prompt : String =
   #|
   #|By using this TODO tool effectively, you can maintain better organization, provide clear progress visibility, and demonstrate a systematic approach to complex coding tasks.
   #|
-  #|IMPORTANT: BEFORE USING TODO TOOL FOR TASK MANAGEMENT, ALWAYS CONDUCT THOROUGH PROJECT EXPLORATION FIRST!
+  #|## Best Practice Workflow
   #|
-  #|Begin every task by systematically exploring the project:
+  #|For complex tasks, follow this recommended workflow:
   #|
-  #|1. Use search_files to understand the project structure and locate relevant files
-  #|2. Use execute_command with grep patterns to find specific code patterns and implementations
-  #|3. Search for existing AC modules that might provide functionality you can reuse
+  #|1. **Create high-level todos immediately** when you identify a complex task
+  #|2. **Explore the project** as needed to refine your understanding of each task
+  #|3. **Update todos** with more specific subtasks as you learn more about the codebase
+  #|4. **Mark tasks in-progress** as you begin working on them
+  #|5. **Mark completed** promptly after finishing each task
   #|
-  #|Only after gathering sufficient information about the project structure, existing patterns, and available modules should you proceed to planning tasks with TODO tools.
+  #|This approach allows you to organize work upfront while remaining flexible to adjust plans as you discover more about the project.
   #|
   #|The TODO tool helps you manage and track task progress during complex coding sessions. It provides structured task management capabilities that enhance productivity and demonstrate thoroughness to users.

--- a/tools/todo/prompt.md
+++ b/tools/todo/prompt.md
@@ -27,20 +27,18 @@ output showing tasks grouped by status with summary statistics.
 
 ### Writing/Managing Tasks
 
-Use write actions (create, add_task, update, mark_progress, mark_completed) proactively in these scenarios, but ONLY AFTER thorough project exploration:
+Use write actions (create, add_task, update, mark_progress, mark_completed) proactively in these scenarios:
 
-- **FIRST EXPLORE THE PROJECT**: Always start with project exploration using
-  search_files, execute_command, and AC module searches
 - **Complex multi-step tasks**: When a task requires 3 or more distinct steps or
-  actions
+  actions - create the todo list FIRST, then explore as needed for each step
 - **Non-trivial and complex tasks**: Tasks that require careful planning or
   multiple operations
 - **User explicitly requests todo list**: When the user directly asks you to use
   the todo list
 - **User provides multiple tasks**: When users provide a list of things to be
-  done (numbered or comma-separated)
+  done (numbered or comma-separated) - capture these immediately
 - **After receiving new instructions**: Immediately capture user requirements as
-  todos, but explore the codebase first
+  high-level todos, then refine as you explore
 - **When you start working on a task**: Mark it as in_progress BEFORE beginning
   work (ideally only one task should be in_progress at a time)
 - **After completing a task**: Mark it as completed and add any new follow-up
@@ -98,14 +96,16 @@ Thinking: The assistant used the todo list because:
 
 By using this TODO tool effectively, you can maintain better organization, provide clear progress visibility, and demonstrate a systematic approach to complex coding tasks.
 
-IMPORTANT: BEFORE USING TODO TOOL FOR TASK MANAGEMENT, ALWAYS CONDUCT THOROUGH PROJECT EXPLORATION FIRST!
+## Best Practice Workflow
 
-Begin every task by systematically exploring the project:
+For complex tasks, follow this recommended workflow:
 
-1. Use search_files to understand the project structure and locate relevant files
-2. Use execute_command with grep patterns to find specific code patterns and implementations
-3. Search for existing AC modules that might provide functionality you can reuse
+1. **Create high-level todos immediately** when you identify a complex task
+2. **Explore the project** as needed to refine your understanding of each task
+3. **Update todos** with more specific subtasks as you learn more about the codebase
+4. **Mark tasks in-progress** as you begin working on them
+5. **Mark completed** promptly after finishing each task
 
-Only after gathering sufficient information about the project structure, existing patterns, and available modules should you proceed to planning tasks with TODO tools.
+This approach allows you to organize work upfront while remaining flexible to adjust plans as you discover more about the project.
 
 The TODO tool helps you manage and track task progress during complex coding sessions. It provides structured task management capabilities that enhance productivity and demonstrate thoroughness to users.


### PR DESCRIPTION
- Make todo tool usage mandatory for complex tasks (3+ steps)
- Remove 'explore first, todo second' requirement that created chicken-egg problem
- Encourage creating high-level todos immediately, then refining during exploration
- Clarify todos should organize work, not be created after planning is done

The previous prompts had conflicting guidance that discouraged todo tool usage:
1. prelude.md made it conditional ('check if you need')
2. todo/prompt.md required thorough exploration BEFORE using todos
3. This caused agents to finish exploration/planning before creating todos

Now agents will create todos at the start of complex tasks for better organization.

cc @tonyfettes tested with yaml/ini parser, works ok
