### PR TITLE
refactor(agent): Event -> OutgoingEvent

### DIFF
--- a/agent/agent_event.mbt
+++ b/agent/agent_event.mbt
@@ -20,7 +20,7 @@
 ///
 /// * `agent` : The agent instance emitting the event.
 /// * `event` : The event to emit and log.
-fn Agent::emit(agent : Agent, event : @event.Event) -> Unit {
+fn Agent::emit(agent : Agent, event : @event.OutgoingEvent) -> Unit {
   agent.event_target.emit(event)
 }
 
@@ -35,7 +35,7 @@ fn Agent::emit(agent : Agent, event : @event.Event) -> Unit {
 ///   event data.
 pub fn Agent::add_listener(
   agent : Agent,
-  f : async (@event.Event) -> Unit,
+  f : async (@event.OutgoingEvent) -> Unit,
 ) -> Unit {
   agent.event_target.add_listener(f)
 }

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -26,7 +26,7 @@ pub(all) struct Agent {
   mut web_search : Bool
   // private fields
 }
-pub fn Agent::add_listener(Self, async (@event.Event) -> Unit) -> Unit
+pub fn Agent::add_listener(Self, async (@event.OutgoingEvent) -> Unit) -> Unit
 pub fn[Output : ToJson + Show] Agent::add_tool(Self, @tool.Tool[Output]) -> Unit
 pub fn Agent::add_tools(Self, Array[@tool.AgentTool]) -> Unit
 pub fn Agent::clear_inputs(Self) -> Array[QueuedMessage]

--- a/event/event.mbt
+++ b/event/event.mbt
@@ -28,6 +28,12 @@
 /// PostConversation
 /// ```
 pub(all) enum Event {
+  Incoming(ExternalEvent)
+  Outgoing(OutgoingEvent)
+}
+
+///|
+pub(all) enum OutgoingEvent {
   /// Event triggered when a model is loaded.
   ModelLoaded(name~ : String, model~ : @model.Model)
   /// Event triggered before a conversation starts.
@@ -95,7 +101,7 @@ pub(all) enum Event {
 }
 
 ///|
-pub impl ToJson for Event with to_json(self : Event) -> Json {
+pub impl ToJson for OutgoingEvent with to_json(self : OutgoingEvent) -> Json {
   match self {
     ModelLoaded(name~, model~) =>
       {

--- a/event/event_target.mbt
+++ b/event/event_target.mbt
@@ -22,8 +22,8 @@ struct EventTarget {
   // TODO: Consider adding a `Closed` event variant instead of using `Event?`.
   // This would make the termination signal explicit in the type system rather
   // than using `None` as a sentinel value.
-  queue : @aqueue.Queue[Event?]
-  listeners : Array[async (Event) -> Unit]
+  queue : @aqueue.Queue[OutgoingEvent?]
+  listeners : Array[async (OutgoingEvent) -> Unit]
 }
 
 ///|
@@ -74,7 +74,7 @@ pub fn EventTarget::new() -> EventTarget {
 /// emitter.emit(TokenCounted(1500))
 /// emitter.emit(PostConversation)
 /// ```
-pub fn EventTarget::emit(self : EventTarget, event : Event) -> Unit {
+pub fn EventTarget::emit(self : EventTarget, event : OutgoingEvent) -> Unit {
   guard self.queue.try_put(Some(event)) else {
     abort("Event queue is full, cannot emit event")
   }
@@ -111,7 +111,7 @@ pub fn EventTarget::emit(self : EventTarget, event : Event) -> Unit {
 /// ```
 pub fn EventTarget::add_listener(
   self : EventTarget,
-  f : async (Event) -> Unit,
+  f : async (OutgoingEvent) -> Unit,
 ) -> Unit {
   self.listeners.push(f)
 }

--- a/event/event_test.mbt
+++ b/event/event_test.mbt
@@ -1,5 +1,5 @@
 ///|
-fn redact_events(events : Array[@event.Event]) -> Array[Json] {
+fn redact_events(events : Array[@event.OutgoingEvent]) -> Array[Json] {
   events.map(event => event
     .to_json()
     .transform(

--- a/event/pkg.generated.mbti
+++ b/event/pkg.generated.mbti
@@ -15,6 +15,31 @@ import(
 
 // Types and methods
 pub(all) enum Event {
+  Incoming(ExternalEvent)
+  Outgoing(OutgoingEvent)
+}
+
+type EventTarget
+pub fn EventTarget::add_listener(Self, async (OutgoingEvent) -> Unit) -> Unit
+pub async fn EventTarget::close(Self) -> Unit
+pub fn EventTarget::emit(Self, OutgoingEvent) -> Unit
+pub async fn EventTarget::flush(Self) -> Unit
+pub fn EventTarget::new() -> Self
+pub async fn EventTarget::start(Self) -> Unit
+
+pub(all) enum ExternalEvent {
+  Diagnostics(@diagnostics.Diagnostics)
+  UserCancellation
+  UserMessage(String)
+}
+pub impl ToJson for ExternalEvent
+
+type ExternalEventQueue
+pub fn ExternalEventQueue::new() -> Self
+pub fn ExternalEventQueue::poll(Self) -> Array[ExternalEvent]
+pub fn ExternalEventQueue::send(Self, ExternalEvent) -> Unit
+
+pub(all) enum OutgoingEvent {
   ModelLoaded(name~ : String, model~ : @model.Model)
   PreConversation
   PostConversation
@@ -31,27 +56,7 @@ pub(all) enum Event {
   Cancelled
   TodoUpdated(Json)
 }
-pub impl ToJson for Event
-
-type EventTarget
-pub fn EventTarget::add_listener(Self, async (Event) -> Unit) -> Unit
-pub async fn EventTarget::close(Self) -> Unit
-pub fn EventTarget::emit(Self, Event) -> Unit
-pub async fn EventTarget::flush(Self) -> Unit
-pub fn EventTarget::new() -> Self
-pub async fn EventTarget::start(Self) -> Unit
-
-pub(all) enum ExternalEvent {
-  Diagnostics(@diagnostics.Diagnostics)
-  UserCancellation
-  UserMessage(String)
-}
-pub impl ToJson for ExternalEvent
-
-type ExternalEventQueue
-pub fn ExternalEventQueue::new() -> Self
-pub fn ExternalEventQueue::poll(Self) -> Array[ExternalEvent]
-pub fn ExternalEventQueue::send(Self, ExternalEvent) -> Unit
+pub impl ToJson for OutgoingEvent
 
 // Type aliases
 


### PR DESCRIPTION
This PR introduces a unified `Event` type to represent both `ExternalEvent` and `OutgoingEvent` (old `Event`).

Using a unified `Event` type allow us to change the disk storage type from `Array[@ai.Message]` to `Array[@event.Event]`, allowing more events to be stored to disk.

Additionally, we can read events from disk and send to client directly with this PR, allowing a much more simple server implementation.