### PR TITLE
feat(event): implement ToJson & FromJson

### DIFF
--- a/agent/agent_tool.mbt
+++ b/agent/agent_tool.mbt
@@ -106,7 +106,7 @@ async fn Agent::execute_tool(
   }
   let (result, rendered) = match tool.call(arguments) {
     Ok((json, text)) => (Ok(json), text)
-    Error(error, text) => (Err(error), text)
+    Error(error, text) => (Err(error.to_json()), text)
   }
   agent.emit(PostToolCall(tool_call, result~, rendered~))
   @ai.tool_message(content=rendered, tool_call_id=tool_call.id)

--- a/ai/message.mbt
+++ b/ai/message.mbt
@@ -4,7 +4,7 @@ pub enum Message {
   System(String)
   Assistant(String, tool_calls~ : Array[ToolCall])
   Tool(String, tool_call_id~ : String)
-} derive(ToJson)
+} derive(ToJson, Eq, Show)
 
 ///|
 pub fn user_message(content~ : String) -> Message {
@@ -44,7 +44,7 @@ pub struct ToolCall {
   id : String
   name : String
   arguments : String?
-} derive(ToJson)
+} derive(ToJson, Eq, Show)
 
 ///|
 pub fn tool_call(id~ : String, name~ : String, arguments? : String) -> ToolCall {
@@ -57,7 +57,7 @@ pub struct Usage {
   output_tokens : Int
   total_tokens : Int
   cache_read_tokens : Int?
-}
+} derive(Eq, Show)
 
 ///|
 pub fn usage(

--- a/ai/pkg.generated.mbti
+++ b/ai/pkg.generated.mbti
@@ -31,6 +31,8 @@ pub fn Message::content(Self) -> String
 pub fn Message::from_openai(@openai.ChatCompletionMessageParam) -> Self
 pub fn Message::from_openai_response(@openai.ChatCompletionMessage) -> Self
 pub fn Message::to_openai(Self) -> @openai.ChatCompletionMessageParam
+pub impl Eq for Message
+pub impl Show for Message
 pub impl ToJson for Message
 
 pub struct ToolCall {
@@ -40,6 +42,8 @@ pub struct ToolCall {
 }
 pub fn ToolCall::from_openai_tool_call(@openai.ChatCompletionMessageToolCall) -> Self
 pub fn ToolCall::to_openai(Self) -> @openai.ChatCompletionMessageToolCall
+pub impl Eq for ToolCall
+pub impl Show for ToolCall
 pub impl ToJson for ToolCall
 
 pub struct Usage {
@@ -50,6 +54,8 @@ pub struct Usage {
 }
 pub fn Usage::from_openai(@openai.CompletionUsage) -> Self
 pub fn Usage::to_openai(Self) -> @openai.CompletionUsage
+pub impl Eq for Usage
+pub impl Show for Usage
 
 // Type aliases
 

--- a/cmd/server/server_test.mbt
+++ b/cmd/server/server_test.mbt
@@ -834,6 +834,7 @@ async test "GET /v1/external-event/cancel" (t : @test.Test) {
       .length(),
       content=1,
     )
+    println(events.to_json().stringify(indent=2))
     @json.inspect(
       events
       .filter(e => e

--- a/event/event.mbt
+++ b/event/event.mbt
@@ -30,7 +30,7 @@
 pub(all) enum Event {
   Incoming(ExternalEvent)
   Outgoing(OutgoingEvent)
-}
+} derive(Eq, Show)
 
 ///|
 pub(all) enum OutgoingEvent {
@@ -70,7 +70,7 @@ pub(all) enum OutgoingEvent {
   /// The `result` field can be used to determine whether the tool call was
   /// successful or not. `rendered` field is the string representation of the
   /// tool call result, which can be used for both human and LLM consumption.
-  PostToolCall(@ai.ToolCall, result~ : Result[Json, Error], rendered~ : String)
+  PostToolCall(@ai.ToolCall, result~ : Result[Json, Json], rendered~ : String)
   /// Event triggered when tokens are counted for a message or tool call.
   /// Tokens are counted in following scenarios:
   ///
@@ -98,7 +98,7 @@ pub(all) enum OutgoingEvent {
   Cancelled
   /// Event triggered when the todo list is updated.
   TodoUpdated(Json)
-}
+} derive(Eq, Show)
 
 ///|
 pub impl ToJson for OutgoingEvent with to_json(self : OutgoingEvent) -> Json {
@@ -205,5 +205,308 @@ pub impl ToJson for OutgoingEvent with to_json(self : OutgoingEvent) -> Json {
       { "msg": "ExternalEventReceived", "event": external_event.to_json() }
     Cancelled => { "msg": "MariaCancelled" }
     TodoUpdated(todo) => { "msg": "TodoUpdated", "todo": todo.to_json() }
+  }
+}
+
+///|
+pub impl @json.FromJson for OutgoingEvent with from_json(
+  json : Json,
+  json_path : @json.JsonPath,
+) -> OutgoingEvent raise @json.JsonDecodeError {
+  guard json is Object({ "msg": String(msg), .. } as json_object) else {
+    raise @json.JsonDecodeError(
+      (json_path, "Missing 'msg' field in OutgoingEvent"),
+    )
+  }
+  match msg {
+    "ModelLoaded" => {
+      guard json_object.get("name") is Some(name_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "ModelLoaded event missing 'name' field"),
+        )
+      }
+      let name : String = @json.FromJson::from_json(
+        name_json,
+        json_path.add_key("name"),
+      )
+      guard json_object.get("model") is Some(model_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "ModelLoaded event missing 'model' field"),
+        )
+      }
+      let model : @model.Model = @json.FromJson::from_json(
+        model_json,
+        json_path.add_key("model"),
+      )
+      ModelLoaded(name~, model~)
+    }
+    "TokenCounted" => {
+      guard json_object.get("token_count") is Some(token_count_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "TokenCounted event missing 'token_count' field"),
+        )
+      }
+      let token_count : Int = @json.FromJson::from_json(
+        token_count_json,
+        json_path.add_key("token_count"),
+      )
+      TokenCounted(token_count)
+    }
+    "ContextPruned" => {
+      guard json_object.get("origin_token_count")
+        is Some(origin_token_count_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "ContextPruned event missing 'origin_token_count' field"),
+        )
+      }
+      let origin_token_count : Int = @json.FromJson::from_json(
+        origin_token_count_json,
+        json_path.add_key("origin_token_count"),
+      )
+      guard json_object.get("pruned_token_count")
+        is Some(pruned_token_count_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "ContextPruned event missing 'pruned_token_count' field"),
+        )
+      }
+      let pruned_token_count : Int = @json.FromJson::from_json(
+        pruned_token_count_json,
+        json_path.add_key("pruned_token_count"),
+      )
+      ContextPruned(origin_token_count~, pruned_token_count~)
+    }
+    "PreToolCall" => {
+      guard json_object.get("tool_call") is Some(tool_call_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "PreToolCall event missing 'tool_call' field"),
+        )
+      }
+      let tool_call : @openai.ChatCompletionMessageToolCall = @json.from_json(
+        tool_call_json,
+        path=json_path.add_key("tool_call"),
+      )
+      PreToolCall(@ai.ToolCall::from_openai_tool_call(tool_call))
+    }
+    "PostToolCall" => {
+      guard json_object.get("tool_call") is Some(tool_call_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "PostToolCall event missing 'tool_call' field"),
+        )
+      }
+      let tool_call : @openai.ChatCompletionMessageToolCall = @json.from_json(
+        tool_call_json,
+        path=json_path.add_key("tool_call"),
+      )
+      let result : Result[Json, Json] = match
+        (json_object.get("result"), json_object.get("error")) {
+        (Some(result_json), _) => Ok(result_json)
+        (None, Some(error_json)) => Err(error_json)
+        (None, None) =>
+          raise @json.JsonDecodeError(
+            (
+              json_path, "PostToolCall event missing both 'result' and 'error' fields",
+            ),
+          )
+      }
+      guard json_object.get("text") is Some(rendered_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "PostToolCall event missing 'text' field"),
+        )
+      }
+      let rendered : String = @json.FromJson::from_json(
+        rendered_json,
+        json_path.add_key("text"),
+      )
+      PostToolCall(
+        @ai.ToolCall::from_openai_tool_call(tool_call),
+        result~,
+        rendered~,
+      )
+    }
+    "PreConversation" => PreConversation
+    "PostConversation" => PostConversation
+    "MessageAdded" => {
+      guard json_object.get("message") is Some(message_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "MessageAdded event missing 'message' field"),
+        )
+      }
+      let message : @openai.ChatCompletionMessageParam = @json.FromJson::from_json(
+        message_json,
+        json_path.add_key("message"),
+      )
+      MessageAdded(@ai.Message::from_openai(message))
+    }
+    "MessageQueued" => {
+      guard json_object.get("message") is Some(message_wrapper_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "MessageQueued event missing 'message' field"),
+        )
+      }
+      guard message_wrapper_json
+        is Object({ "id": id_json, "message": msg_json, .. }) else {
+        raise @json.JsonDecodeError(
+          (json_path, "Invalid 'message' field in MessageQueued event"),
+        )
+      }
+      let id : @uuid.Uuid = @json.FromJson::from_json(
+        id_json,
+        json_path.add_key("message").add_key("id"),
+      )
+      let message : @openai.ChatCompletionMessageParam = @json.FromJson::from_json(
+        msg_json,
+        json_path.add_key("message").add_key("message"),
+      )
+      MessageQueued(id~, @ai.Message::from_openai(message))
+    }
+    "MessageUnqueued" => {
+      guard json_object.get("message") is Some(message_wrapper_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "MessageUnqueued event missing 'message' field"),
+        )
+      }
+      guard message_wrapper_json is Object({ "id": id_json, .. }) else {
+        raise @json.JsonDecodeError(
+          (json_path, "Invalid 'message' field in MessageUnqueued event"),
+        )
+      }
+      let id : @uuid.Uuid = @json.FromJson::from_json(
+        id_json,
+        json_path.add_key("message").add_key("id"),
+      )
+      MessageUnqueued(id~)
+    }
+    "ToolAdded" => {
+      guard json_object.get("tool") is Some(tool_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "ToolAdded event missing 'tool' field"),
+        )
+      }
+      guard tool_json
+        is Object(
+          {
+            "name": name_json,
+            "description": description_json,
+            "schema": schema_json,
+            ..
+          }
+        ) else {
+        raise @json.JsonDecodeError(
+          (json_path, "Invalid 'tool' field in ToolAdded event"),
+        )
+      }
+      let name : String = @json.FromJson::from_json(
+        name_json,
+        json_path.add_key("tool").add_key("name"),
+      )
+      let description : String = @json.FromJson::from_json(
+        description_json,
+        json_path.add_key("tool").add_key("description"),
+      )
+      let schema : Json = schema_json
+      ToolAdded(@tool.tool_desc(description~, name~, schema~))
+    }
+    "RequestCompleted" => {
+      guard json_object.get("usage") is Some(usage_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "RequestCompleted event missing 'usage' field"),
+        )
+      }
+      let usage : @ai.Usage? = match usage_json {
+        Null => None
+        Array([usage_obj]) =>
+          Some(
+            @ai.Usage::from_openai(
+              @json.FromJson::from_json(
+                usage_obj,
+                json_path.add_key("usage").add_index(0),
+              ),
+            ),
+          )
+        _ =>
+          raise @json.JsonDecodeError(
+            (
+              json_path.add_key("usage"),
+              "Expected null or array with one element for usage",
+            ),
+          )
+      }
+      guard json_object.get("message") is Some(message_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "RequestCompleted event missing 'message' field"),
+        )
+      }
+      let message : @openai.ChatCompletionMessageParam = @json.FromJson::from_json(
+        message_json,
+        json_path.add_key("message"),
+      )
+      RequestCompleted(usage~, message=@ai.Message::from_openai(message))
+    }
+    "ExternalEventReceived" => {
+      guard json_object.get("event") is Some(event_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "ExternalEventReceived event missing 'event' field"),
+        )
+      }
+      let external_event : ExternalEvent = ExternalEvent::from_json(
+        event_json,
+        json_path.add_key("event"),
+      )
+      ExternalEventReceived(external_event)
+    }
+    "MariaCancelled" => Cancelled
+    "TodoUpdated" => {
+      guard json_object.get("todo") is Some(todo_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "TodoUpdated event missing 'todo' field"),
+        )
+      }
+      let todo : Json = @json.FromJson::from_json(
+        todo_json,
+        json_path.add_key("todo"),
+      )
+      TodoUpdated(todo)
+    }
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path, "Unknown 'msg' value in OutgoingEvent: \{msg}"),
+      )
+  }
+}
+
+///|
+pub impl ToJson for Event with to_json(self : Event) -> Json {
+  match self {
+    Incoming(external_event) =>
+      { "kind": "Incoming", "external_event": external_event.to_json() }
+    Outgoing(outgoing_event) =>
+      { "kind": "Outgoing", "outgoing_event": outgoing_event.to_json() }
+  }
+}
+
+///|
+pub impl @json.FromJson for Event with from_json(
+  json : Json,
+  json_path : @json.JsonPath,
+) -> Event raise @json.JsonDecodeError {
+  match json {
+    { "kind": "Incoming", "external_event": external_event_json, .. } =>
+      Incoming(
+        ExternalEvent::from_json(
+          external_event_json,
+          json_path.add_key("external_event"),
+        ),
+      )
+    { "kind": "Outgoing", "outgoing_event": outgoing_event_json, .. } =>
+      Outgoing(
+        OutgoingEvent::from_json(
+          outgoing_event_json,
+          json_path.add_key("outgoing_event"),
+        ),
+      )
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path, "Invalid Event object: missing or unknown 'kind' field"),
+      )
   }
 }

--- a/event/event_test.mbt
+++ b/event/event_test.mbt
@@ -168,7 +168,7 @@ async test "Event::ToJson/PostToolCall error" (t : @test.Test) {
             name="failing_tool",
             arguments="{\"paramA\": \"valueA\"}",
           ),
-          result=Err(Failure("Tool call error")),
+          result=Err(Failure("Tool call error").to_json()),
           rendered="Tool call error output",
         ),
       )
@@ -320,4 +320,556 @@ async test "Event::ModelLoaded" (t : @test.Test) {
       },
     ])
   })
+}
+
+///|
+test "Event::Roundtrip/PreConversation" {
+  let event : @event.OutgoingEvent = PreConversation
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    PreConversation => ()
+    _ => fail("Expected PreConversation")
+  }
+}
+
+///|
+test "Event::Roundtrip/PostConversation" {
+  let event : @event.OutgoingEvent = PostConversation
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    PostConversation => ()
+    _ => fail("Expected PostConversation")
+  }
+}
+
+///|
+test "Event::Roundtrip/TokenCounted" {
+  let event : @event.OutgoingEvent = TokenCounted(42)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    TokenCounted(count) => inspect(count, content="42")
+    _ => fail("Expected TokenCounted")
+  }
+}
+
+///|
+test "Event::Roundtrip/ContextPruned" {
+  let event : @event.OutgoingEvent = ContextPruned(
+    origin_token_count=100,
+    pruned_token_count=20,
+  )
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    ContextPruned(origin_token_count~, pruned_token_count~) => {
+      inspect(origin_token_count, content="100")
+      inspect(pruned_token_count, content="20")
+    }
+    _ => fail("Expected ContextPruned")
+  }
+}
+
+///|
+test "Event::Roundtrip/PreToolCall" {
+  let tool_call = @ai.tool_call(
+    id="tool_call_1",
+    name="example_tool",
+    arguments="{\"param1\": \"value1\", \"param2\": 123}",
+  )
+  let event : @event.OutgoingEvent = PreToolCall(tool_call)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    PreToolCall(tc) => {
+      inspect(tc.id, content="tool_call_1")
+      inspect(tc.name, content="example_tool")
+      inspect(
+        tc.arguments,
+        content=(
+          #|Some("{\"param1\": \"value1\", \"param2\": 123}")
+        ),
+      )
+    }
+    _ => fail("Expected PreToolCall")
+  }
+}
+
+///|
+test "Event::Roundtrip/PostToolCall/Ok" {
+  let tool_call = @ai.tool_call(
+    id="tool_call_1",
+    name="example_tool",
+    arguments="{\"param1\": \"value1\"}",
+  )
+  let event : @event.OutgoingEvent = PostToolCall(
+    tool_call,
+    result=Ok({ "output": "success" }),
+    rendered="Tool output: success",
+  )
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    PostToolCall(tc, result~, rendered~) => {
+      inspect(tc.id, content="tool_call_1")
+      inspect(tc.name, content="example_tool")
+      inspect(
+        result,
+        content=(
+          #|Ok(Object({"output": String("success")}))
+        ),
+      )
+      inspect(rendered, content="Tool output: success")
+    }
+    _ => fail("Expected PostToolCall")
+  }
+}
+
+///|
+test "Event::Roundtrip/PostToolCall/Err" {
+  let tool_call = @ai.tool_call(
+    id="tool_call_2",
+    name="failing_tool",
+    arguments="{}",
+  )
+  let event : @event.OutgoingEvent = PostToolCall(
+    tool_call,
+    result=Err({ "error": "Something went wrong" }),
+    rendered="Error occurred",
+  )
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    PostToolCall(tc, result~, rendered~) => {
+      inspect(tc.id, content="tool_call_2")
+      inspect(
+        result,
+        content=(
+          #|Err(Object({"error": String("Something went wrong")}))
+        ),
+      )
+      inspect(rendered, content="Error occurred")
+    }
+    _ => fail("Expected PostToolCall")
+  }
+}
+
+///|
+test "Event::Roundtrip/MessageAdded" {
+  let message = @ai.user_message(content="Hello, world!")
+  let event : @event.OutgoingEvent = MessageAdded(message)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    MessageAdded(msg) => inspect(msg.content(), content="Hello, world!")
+    _ => fail("Expected MessageAdded")
+  }
+}
+
+///|
+test "Event::Roundtrip/MessageQueued" {
+  let id = @uuid.nil
+  let message = @ai.system_message(content="System prompt")
+  let event : @event.OutgoingEvent = MessageQueued(id~, message)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    MessageQueued(id=roundtrip_id, msg) => {
+      inspect(roundtrip_id == id, content="true")
+      inspect(msg.content(), content="System prompt")
+    }
+    _ => fail("Expected MessageQueued")
+  }
+}
+
+///|
+test "Event::Roundtrip/MessageUnqueued" {
+  let id = @uuid.nil
+  let event : @event.OutgoingEvent = MessageUnqueued(id~)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    MessageUnqueued(id=roundtrip_id) =>
+      inspect(roundtrip_id == id, content="true")
+    _ => fail("Expected MessageUnqueued")
+  }
+}
+
+///|
+test "Event::Roundtrip/ToolAdded" {
+  let tool_desc = @tool.tool_desc(
+    name="sample_tool",
+    description="A sample tool",
+    schema=@tool.JsonSchema::from_json({ "type": "object" }),
+  )
+  let event : @event.OutgoingEvent = ToolAdded(tool_desc)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    ToolAdded(desc) => {
+      inspect(desc.name, content="sample_tool")
+      inspect(desc.description, content="A sample tool")
+      inspect(
+        desc.schema.to_json(),
+        content=(
+          #|Object({"type": String("object")})
+        ),
+      )
+    }
+    _ => fail("Expected ToolAdded")
+  }
+}
+
+///|
+test "Event::Roundtrip/RequestCompleted/WithUsage" {
+  let usage = @ai.usage(input_tokens=100, output_tokens=50, total_tokens=150)
+  let message = @ai.assistant_message(content="Response from model", tool_calls=[])
+  let event : @event.OutgoingEvent = RequestCompleted(
+    usage=Some(usage),
+    message~,
+  )
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    RequestCompleted(usage=roundtrip_usage, message=msg) => {
+      match roundtrip_usage {
+        Some(u) => {
+          inspect(u.input_tokens, content="100")
+          inspect(u.output_tokens, content="50")
+          inspect(u.total_tokens, content="150")
+        }
+        None => fail("Expected Some(usage)")
+      }
+      inspect(msg.content(), content="Response from model")
+    }
+    _ => fail("Expected RequestCompleted")
+  }
+}
+
+///|
+test "Event::Roundtrip/RequestCompleted/NoUsage" {
+  let message = @ai.assistant_message(content="Response", tool_calls=[])
+  let event : @event.OutgoingEvent = RequestCompleted(usage=None, message~)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    RequestCompleted(usage=roundtrip_usage, message=msg) => {
+      match roundtrip_usage {
+        None => ()
+        Some(_) => fail("Expected None")
+      }
+      inspect(msg.content(), content="Response")
+    }
+    _ => fail("Expected RequestCompleted")
+  }
+}
+
+///|
+test "Event::Roundtrip/Cancelled" {
+  let event : @event.OutgoingEvent = Cancelled
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    Cancelled => ()
+    _ => fail("Expected Cancelled")
+  }
+}
+
+///|
+test "Event::Roundtrip/TodoUpdated" {
+  let todo_json : Json = { "task": "Do something", "status": "pending" }
+  let event : @event.OutgoingEvent = TodoUpdated(todo_json)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    TodoUpdated(todo) =>
+      inspect(
+        todo,
+        content=(
+          #|Object({"task": String("Do something"), "status": String("pending")})
+        ),
+      )
+    _ => fail("Expected TodoUpdated")
+  }
+}
+
+///|
+test "Event::Roundtrip/ModelLoaded" {
+  let model = @model.Model::new(
+    api_key="test_api_key",
+    base_url="https://api.example.com",
+    name="test_model",
+    safe_zone_tokens=100000,
+  )
+  let event : @event.OutgoingEvent = ModelLoaded(name="my_model", model~)
+  let json = event.to_json()
+  let roundtripped : @event.OutgoingEvent = @json.from_json(json)
+  match roundtripped {
+    ModelLoaded(name~, model=roundtrip_model) => {
+      inspect(name, content="my_model")
+      inspect(roundtrip_model.name, content="test_model")
+      inspect(roundtrip_model.base_url, content="https://api.example.com")
+      inspect(roundtrip_model.safe_zone_tokens, content="100000")
+    }
+    _ => fail("Expected ModelLoaded")
+  }
+}
+
+///|
+test "ExternalEvent::Roundtrip/UserCancellation" {
+  let event : @event.ExternalEvent = UserCancellation
+  let json = event.to_json()
+  let roundtripped : @event.ExternalEvent = @json.from_json(json)
+  match roundtripped {
+    UserCancellation => ()
+    _ => fail("Expected UserCancellation")
+  }
+}
+
+///|
+test "ExternalEvent::Roundtrip/UserMessage" {
+  let event : @event.ExternalEvent = UserMessage("Stop the current task")
+  let json = event.to_json()
+  let roundtripped : @event.ExternalEvent = @json.from_json(json)
+  match roundtripped {
+    UserMessage(msg) => inspect(msg, content="Stop the current task")
+    _ => fail("Expected UserMessage")
+  }
+}
+
+///|
+test "ExternalEvent::Roundtrip/Diagnostics" {
+  let diagnostic = @diagnostics.Diagnostic::{
+    error_code: 1001,
+    level: @diagnostics.Level::Error,
+    loc: @diagnostics.Loc::{
+      path: "/path/to/file.mbt",
+      start: @diagnostics.Pos::{ line: 10, col: 5 },
+      end: @diagnostics.Pos::{ line: 10, col: 15 },
+    },
+    message: "Type mismatch error",
+  }
+  let diagnostics = @diagnostics.Diagnostics::new()
+  diagnostics.push(diagnostic)
+  let event : @event.ExternalEvent = Diagnostics(diagnostics)
+  let json = event.to_json()
+  let roundtripped : @event.ExternalEvent = @json.from_json(json)
+  match roundtripped {
+    Diagnostics(diags) => {
+      inspect(diags.length(), content="1")
+      let diag = diags.0[0]
+      inspect(diag.error_code, content="1001")
+      inspect(diag.level, content="Error")
+      inspect(diag.loc.path, content="/path/to/file.mbt")
+      inspect(diag.loc.start.line, content="10")
+      inspect(diag.loc.start.col, content="5")
+      inspect(diag.message, content="Type mismatch error")
+    }
+    _ => fail("Expected Diagnostics")
+  }
+}
+
+///|
+test "ExternalEvent::Roundtrip/Diagnostics/Multiple" {
+  let diagnostic1 = @diagnostics.Diagnostic::{
+    error_code: 1001,
+    level: @diagnostics.Level::Error,
+    loc: @diagnostics.Loc::{
+      path: "/path/to/file1.mbt",
+      start: @diagnostics.Pos::{ line: 10, col: 5 },
+      end: @diagnostics.Pos::{ line: 10, col: 15 },
+    },
+    message: "First error",
+  }
+  let diagnostic2 = @diagnostics.Diagnostic::{
+    error_code: 2002,
+    level: @diagnostics.Level::Warning,
+    loc: @diagnostics.Loc::{
+      path: "/path/to/file2.mbt",
+      start: @diagnostics.Pos::{ line: 20, col: 3 },
+      end: @diagnostics.Pos::{ line: 20, col: 8 },
+    },
+    message: "Unused variable",
+  }
+  let diagnostics = @diagnostics.Diagnostics::new()
+  diagnostics.push(diagnostic1)
+  diagnostics.push(diagnostic2)
+  let event : @event.ExternalEvent = Diagnostics(diagnostics)
+  @json.inspect(event, content={
+    "type": "Diagnostics",
+    "diagnostics": [
+      "Diagnostics",
+      [
+        {
+          "error_code": 1001,
+          "level": "Error",
+          "loc": {
+            "end": { "col": 15, "line": 10 },
+            "path": "/path/to/file1.mbt",
+            "start": { "col": 5, "line": 10 },
+          },
+          "message": "First error",
+        },
+        {
+          "error_code": 2002,
+          "level": "Warning",
+          "loc": {
+            "end": { "col": 8, "line": 20 },
+            "path": "/path/to/file2.mbt",
+            "start": { "col": 3, "line": 20 },
+          },
+          "message": "Unused variable",
+        },
+      ],
+    ],
+  })
+  let json = event.to_json()
+  let roundtripped : @event.ExternalEvent = @json.from_json(json)
+  match roundtripped {
+    Diagnostics(diags) => {
+      inspect(diags.length(), content="2")
+      inspect(diags.0[0].message, content="First error")
+      inspect(diags.0[0].level, content="Error")
+      inspect(diags.0[1].message, content="Unused variable")
+      inspect(diags.0[1].level, content="Warning")
+    }
+    _ => fail("Expected Diagnostics")
+  }
+}
+
+///|
+test "ExternalEvent::Roundtrip/Diagnostics/Empty" {
+  let diagnostics = @diagnostics.Diagnostics::new()
+  let event : @event.ExternalEvent = Diagnostics(diagnostics)
+  let json = event.to_json()
+  let roundtripped : @event.ExternalEvent = @json.from_json(json)
+  match roundtripped {
+    Diagnostics(diags) => {
+      inspect(diags.length(), content="0")
+      inspect(diags.is_empty(), content="true")
+    }
+    _ => fail("Expected Diagnostics")
+  }
+}
+
+///|
+test "Event::Roundtrip" {
+  let events : Array[Event] = [
+    Outgoing(PreConversation),
+    Outgoing(PostConversation),
+    Outgoing(TokenCounted(42)),
+    Outgoing(ContextPruned(origin_token_count=100, pruned_token_count=20)),
+    Outgoing(
+      PreToolCall(
+        @ai.tool_call(
+          id="tool_call_1",
+          name="example_tool",
+          arguments="{\"param1\": \"value1\", \"param2\": 123}",
+        ),
+      ),
+    ),
+    Outgoing(
+      PostToolCall(
+        @ai.tool_call(
+          id="tool_call_1",
+          name="example_tool",
+          arguments="{\"param1\": \"value1\", \"param2\": 123}",
+        ),
+        result=Ok("Tool call result"),
+        rendered="Tool call rendered output",
+      ),
+    ),
+    Outgoing(
+      MessageAdded(@ai.user_message(content="Hello, this is a user message.")),
+    ),
+    Outgoing(
+      ToolAdded(
+        @tool.tool_desc(
+          name="sample_tool",
+          description="A sample tool for demonstration.",
+          schema="{\"type\": \"object\", \"properties\": {\"param\": {\"type\": \"string\"}}}",
+        ),
+      ),
+    ),
+    Outgoing(
+      RequestCompleted(
+        usage=Some(
+          @ai.usage(input_tokens=150, output_tokens=50, total_tokens=200),
+        ),
+        message=@ai.assistant_message(
+          content="This is the final message from the model.",
+          tool_calls=[],
+        ),
+      ),
+    ),
+    Outgoing(
+      ModelLoaded(
+        name="test_model",
+        model=@model.Model::new(
+          api_key="****",
+          base_url="https://api.example.com",
+          name="test_model",
+          safe_zone_tokens=100000,
+        ),
+      ),
+    ),
+    Outgoing(Cancelled),
+    Outgoing(TodoUpdated({ "task": "Do something", "status": "pending" })),
+    Incoming(UserCancellation),
+    Incoming(UserMessage("Stop the current task")),
+    Incoming(Diagnostics(@diagnostics.Diagnostics::new())),
+    Incoming(
+      Diagnostics(
+        {
+          let ds = @diagnostics.Diagnostics::new()
+          ds.push(@diagnostics.Diagnostic::{
+            error_code: 1001,
+            level: @diagnostics.Level::Error,
+            loc: @diagnostics.Loc::{
+              path: "/path/to/file.mbt",
+              start: { line: 10, col: 5 },
+              end: { line: 10, col: 15 },
+            },
+            message: "Type mismatch error",
+          })
+          ds
+        },
+      ),
+    ),
+    Incoming(
+      Diagnostics(
+        {
+          let ds = @diagnostics.Diagnostics::new()
+          ds.push(@diagnostics.Diagnostic::{
+            error_code: 1001,
+            level: Error,
+            loc: {
+              path: "/path/to/file1.mbt",
+              start: { line: 10, col: 5 },
+              end: { line: 10, col: 15 },
+            },
+            message: "First error",
+          })
+          ds.push({
+            error_code: 2002,
+            level: Warning,
+            loc: {
+              path: "/path/to/file2.mbt",
+              start: { line: 20, col: 3 },
+              end: { line: 20, col: 8 },
+            },
+            message: "Unused variable",
+          })
+          ds
+        },
+      ),
+    ),
+  ]
+  for event in events {
+    let json = event.to_json()
+    let roundtripped : @event.Event = @json.from_json(json)
+    assert_eq(roundtripped, event)
+  }
 }

--- a/event/external_event.mbt
+++ b/event/external_event.mbt
@@ -8,7 +8,7 @@ pub(all) enum ExternalEvent {
   UserCancellation
   /// User sends an immediate message (interrupting current flow)
   UserMessage(String)
-}
+} derive(Eq, Show)
 
 ///|
 /// A queue for receiving external events from the environment.
@@ -122,11 +122,55 @@ pub fn ExternalEventQueue::poll(
 }
 
 ///|
-pub impl ToJson for ExternalEvent with to_json(self : ExternalEvent) -> Json {
+fn ExternalEvent::to_json_object(self : ExternalEvent) -> Map[String, Json] {
   match self {
     Diagnostics(diagnostics) =>
       { "type": "Diagnostics", "diagnostics": diagnostics.to_json() }
     UserCancellation => { "type": "UserCancellation" }
     UserMessage(message) => { "type": "UserMessage", "message": message }
+  }
+}
+
+///|
+pub impl ToJson for ExternalEvent with to_json(self : ExternalEvent) -> Json {
+  Json::object(self.to_json_object())
+}
+
+///|
+pub impl @json.FromJson for ExternalEvent with from_json(
+  json : Json,
+  json_path : @json.JsonPath,
+) -> ExternalEvent raise @json.JsonDecodeError {
+  guard json is Object({ "type": String(type_), .. } as json_object) else {
+    raise @json.JsonDecodeError(
+      (json_path, "Missing 'type' field in ExternalEvent"),
+    )
+  }
+  match type_ {
+    "Diagnostics" => {
+      guard json_object.get("diagnostics") is Some(diagnostics_json) else {
+        raise @json.JsonDecodeError(
+          (json_path, "Diagnostics event missing 'diagnostics' field"),
+        )
+      }
+      let diagnostics : @diagnostics.Diagnostics = @json.FromJson::from_json(
+        diagnostics_json,
+        json_path.add_key("diagnostics"),
+      )
+      Diagnostics(diagnostics)
+    }
+    "UserCancellation" => UserCancellation
+    "UserMessage" => {
+      guard json_object.get("message") is Some(String(message)) else {
+        raise @json.JsonDecodeError(
+          (json_path, "Missing 'message' field in UserMessage event"),
+        )
+      }
+      UserMessage(message)
+    }
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path, "Unknown 'type' value in ExternalEvent: \{type_}"),
+      )
   }
 }

--- a/event/pkg.generated.mbti
+++ b/event/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/event"
 
 import(
+  "moonbitlang/core/json"
   "moonbitlang/maria/ai"
   "moonbitlang/maria/internal/diagnostics"
   "moonbitlang/maria/internal/uuid"
@@ -18,6 +19,10 @@ pub(all) enum Event {
   Incoming(ExternalEvent)
   Outgoing(OutgoingEvent)
 }
+pub impl Eq for Event
+pub impl Show for Event
+pub impl ToJson for Event
+pub impl @json.FromJson for Event
 
 type EventTarget
 pub fn EventTarget::add_listener(Self, async (OutgoingEvent) -> Unit) -> Unit
@@ -32,7 +37,10 @@ pub(all) enum ExternalEvent {
   UserCancellation
   UserMessage(String)
 }
+pub impl Eq for ExternalEvent
+pub impl Show for ExternalEvent
 pub impl ToJson for ExternalEvent
+pub impl @json.FromJson for ExternalEvent
 
 type ExternalEventQueue
 pub fn ExternalEventQueue::new() -> Self
@@ -48,7 +56,7 @@ pub(all) enum OutgoingEvent {
   MessageQueued(id~ : @uuid.Uuid, @ai.Message)
   ToolAdded(@tool.ToolDesc)
   PreToolCall(@ai.ToolCall)
-  PostToolCall(@ai.ToolCall, result~ : Result[Json, Error], rendered~ : String)
+  PostToolCall(@ai.ToolCall, result~ : Result[Json, Json], rendered~ : String)
   TokenCounted(Int)
   ContextPruned(origin_token_count~ : Int, pruned_token_count~ : Int)
   RequestCompleted(usage~ : @ai.Usage?, message~ : @ai.Message)
@@ -56,7 +64,10 @@ pub(all) enum OutgoingEvent {
   Cancelled
   TodoUpdated(Json)
 }
+pub impl Eq for OutgoingEvent
+pub impl Show for OutgoingEvent
 pub impl ToJson for OutgoingEvent
+pub impl @json.FromJson for OutgoingEvent
 
 // Type aliases
 

--- a/internal/diagnostics/diagnostics.mbt
+++ b/internal/diagnostics/diagnostics.mbt
@@ -1,5 +1,10 @@
 ///|
-pub struct Diagnostics(Array[Diagnostic]) derive(ToJson, Show)
+pub struct Diagnostics(Array[Diagnostic]) derive (
+  ToJson,
+  @json.FromJson,
+  Show,
+  Eq,
+)
 
 ///|
 pub fn Diagnostics::new() -> Self {

--- a/internal/diagnostics/pkg.generated.mbti
+++ b/internal/diagnostics/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub(all) struct Diagnostic {
   loc : Loc
   message : String
 }
+pub impl Eq for Diagnostic
 pub impl Show for Diagnostic
 pub impl ToJson for Diagnostic
 pub impl @json.FromJson for Diagnostic
@@ -33,13 +34,16 @@ pub fn Diagnostics::length(Self) -> Int
 pub fn Diagnostics::new() -> Self
 pub fn Diagnostics::push(Self, Diagnostic) -> Unit
 pub async fn Diagnostics::render(Self, limit~ : Int, context? : Int, overlay? : Map[String, String], cwd? : String) -> String noraise
+pub impl Eq for Diagnostics
 pub impl Show for Diagnostics
 pub impl ToJson for Diagnostics
+pub impl @json.FromJson for Diagnostics
 
 pub(all) enum Level {
   Error
   Warning
 }
+pub impl Eq for Level
 pub impl Show for Level
 pub impl ToJson for Level
 pub impl @json.FromJson for Level
@@ -49,6 +53,7 @@ pub(all) struct Loc {
   path : String
   start : Pos
 }
+pub impl Eq for Loc
 pub impl Show for Loc
 pub impl ToJson for Loc
 pub impl @json.FromJson for Loc
@@ -57,6 +62,7 @@ pub(all) struct Pos {
   col : Int
   line : Int
 }
+pub impl Eq for Pos
 pub impl Show for Pos
 pub impl ToJson for Pos
 pub impl @json.FromJson for Pos

--- a/internal/diagnostics/types.mbt
+++ b/internal/diagnostics/types.mbt
@@ -3,7 +3,7 @@
 pub(all) enum Level {
   Error
   Warning
-} derive(Show, ToJson)
+} derive(Show, ToJson, Eq)
 
 ///|
 pub impl @json.FromJson for Level with from_json(
@@ -22,14 +22,14 @@ pub impl @json.FromJson for Level with from_json(
 pub(all) struct Pos {
   col : Int
   line : Int
-} derive(Show, ToJson, FromJson)
+} derive(Show, ToJson, FromJson, Eq)
 
 ///|
 pub(all) struct Loc {
   end : Pos
   path : String
   start : Pos
-} derive(Show, ToJson, FromJson)
+} derive(Show, ToJson, FromJson, Eq)
 
 ///|
 // FromJson is used when parsing `moon check --output json`
@@ -38,4 +38,4 @@ pub(all) struct Diagnostic {
   level : Level
   loc : Loc
   message : String
-} derive(Show, ToJson, FromJson)
+} derive(Show, ToJson, FromJson, Eq)

--- a/internal/openai/json.mbt
+++ b/internal/openai/json.mbt
@@ -67,7 +67,7 @@ pub impl ToJson for ChatCompletionMessageToolCall with to_json(
 }
 
 ///|
-impl @json.FromJson for ChatCompletionMessageToolCall with from_json(
+pub impl @json.FromJson for ChatCompletionMessageToolCall with from_json(
   json : Json,
   json_path : @json.JsonPath,
 ) -> ChatCompletionMessageToolCall {

--- a/internal/openai/pkg.generated.mbti
+++ b/internal/openai/pkg.generated.mbti
@@ -199,6 +199,7 @@ pub struct ChatCompletionMessageToolCall {
 }
 pub impl Show for ChatCompletionMessageToolCall
 pub impl ToJson for ChatCompletionMessageToolCall
+pub impl @json.FromJson for ChatCompletionMessageToolCall
 
 pub struct ChatCompletionMessageToolCallFunction {
   arguments : String?

--- a/model/model.mbt
+++ b/model/model.mbt
@@ -8,17 +8,17 @@ pub struct Model {
   base_url : String
   safe_zone_tokens : Int
   supports_anthropic_prompt_caching : Bool
-} derive(ToJson)
+} derive(ToJson, Eq, Show)
 
 ///|
 pub(all) enum Provider {
   OpenAI
-}
+} derive(Eq, Show)
 
 ///|
 pub(all) enum Type {
   SaaS(Provider)
-}
+} derive(Eq, Show)
 
 ///|
 /// Create a new model configuration describing how to reach a provider

--- a/model/pkg.generated.mbti
+++ b/model/pkg.generated.mbti
@@ -49,16 +49,22 @@ pub struct Model {
 }
 #as_free_fn
 pub fn Model::new(api_key~ : String, base_url~ : String, name~ : String, safe_zone_tokens~ : Int, model_name? : String, model_type? : Type, description? : String, supports_anthropic_prompt_caching? : Bool) -> Self
+pub impl Eq for Model
+pub impl Show for Model
 pub impl ToJson for Model
 pub impl @json.FromJson for Model
 
 pub(all) enum Provider {
   OpenAI
 }
+pub impl Eq for Provider
+pub impl Show for Provider
 
 pub(all) enum Type {
   SaaS(Provider)
 }
+pub impl Eq for Type
+pub impl Show for Type
 pub impl ToJson for Type
 pub impl @json.FromJson for Type
 

--- a/tool/jsonschema.mbt
+++ b/tool/jsonschema.mbt
@@ -1,5 +1,5 @@
 ///|
-pub(all) struct JsonSchema(Json)
+pub(all) struct JsonSchema(Json) derive(Eq, Show)
 
 ///|
 pub fn JsonSchema::from_json(schema : Json) -> JsonSchema {

--- a/tool/pkg.generated.mbti
+++ b/tool/pkg.generated.mbti
@@ -19,6 +19,8 @@ pub(all) struct JsonSchema(Json)
 pub fn JsonSchema::from_json(Json) -> Self
 #deprecated
 pub fn JsonSchema::inner(Self) -> Json
+pub impl Eq for JsonSchema
+pub impl Show for JsonSchema
 pub impl ToJson for JsonSchema
 
 pub struct Tool[Output] {
@@ -37,6 +39,8 @@ pub struct ToolDesc {
   schema : JsonSchema
 }
 pub fn ToolDesc::to_openai(Self) -> @openai.ChatCompletionToolParam
+pub impl Eq for ToolDesc
+pub impl Show for ToolDesc
 pub impl ToJson for ToolDesc
 
 pub(all) struct ToolFn[Output](async (Json) -> ToolResult[Output] noraise)

--- a/tool/tool.mbt
+++ b/tool/tool.mbt
@@ -3,7 +3,7 @@ pub struct ToolDesc {
   description : String
   name : String
   schema : JsonSchema
-} derive(ToJson)
+} derive(ToJson, Eq, Show)
 
 ///|
 pub fn ToolDesc::to_openai(


### PR DESCRIPTION
This PR adds ToJson/FromJson implementation for `Event` type so that it can be serialized to JSON file and stored on disk.

In order to implement ToJson/FromJson, we have to change the `Error` in `PostToolCall` to `Json` so that we can deserialize from JSON, as it is impossible for now to deserialize to `Error` directly.