### PR TITLE
docs: add js-api documentation

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -1,0 +1,67 @@
+# Task Events
+
+At the TypeScript level (UI side), a task event is defined as `TaskEvent` in
+[`ui/core/src/lib/types.ts`](../ui/core/src/lib/types.ts#L27):
+
+```ts
+type TaskEventBase = { id: number };
+
+export type TaskEvent = TaskEventBase &
+  | RequestCompletedEvent
+  | PreToolCallEvent
+  | PostToolCallEvent
+  | MessageAddedEvent
+  | PostConversationEvent
+  | MessageUnqueuedEvent
+  | TodoUpdatedEvent;
+```
+
+MoonBit: [`event/event.mbt`](../event/event.mbt#L36)
+
+```mbt
+pub(all) enum OutgoingEvent {
+  ModelLoaded(name~ : String, model~ : @model.Model)
+  PreConversation
+  PostConversation
+  MessageAdded(@ai.Message)
+  MessageUnqueued(id~ : @uuid.Uuid)
+  MessageQueued(id~ : @uuid.Uuid, @ai.Message)
+  ToolAdded(@tool.ToolDesc)
+  PreToolCall(@ai.ToolCall)
+  PostToolCall(@ai.ToolCall, result~ : Result[Json, Json], rendered~ : String)
+  TokenCounted(Int)
+  ContextPruned(origin_token_count~ : Int, pruned_token_count~ : Int)
+  RequestCompleted(usage~ : @ai.Usage?, message~ : @ai.Message)
+  ExternalEventReceived(ExternalEvent)
+  Cancelled
+  TodoUpdated(Json)
+}
+```
+
+JSON encoding:
+
+```jsonc
+// All task events share a common "msg" discriminator and optional payload
+// fields. The exact payload depends on the variant.
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000", // randomly generated UUIDv4 per task
+  "msg": "MessageAdded" | "RequestCompleted" | "PreToolCall" |
+         "PostToolCall" | "PostConversation" | "MessageUnqueued" |
+         "TodoUpdated",
+  // ...variant‑specific fields...
+}
+```
+
+The `id` is a randomly generated UUIDv4 per task and is used solely to avoid
+re‑rendering the same event twice on the UI. See
+[`cmd/server/server.mbt`](../cmd/server/server.mbt#L61)
+
+Below are the individual variants and their semantics.
+
+- [`MessageAddedEvent`](events/MessageAdded.md)
+- [`RequestCompletedEvent`](events/RequestCompleted.md)
+- [`PostConversationEvent`](events/PostConversation.md)
+- [`PostToolCallEvent`](events/PostToolCall.md)
+- [`PreToolCallEvent`](events/PreToolCall.md)
+- [`MessageUnqueuedEvent`](events/MessageUnqueued.md)
+- [`TodoUpdatedEvent`](events/TodoUpdated.md)

--- a/docs/events/MessageAdded.md
+++ b/docs/events/MessageAdded.md
@@ -1,0 +1,53 @@
+# `MessageAddedEvent`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L182)
+
+```ts
+type MessageContentPart = { text: string };
+
+type MessageBase = {
+  content: MessageContentPart[] | string;
+};
+
+type SystemMessage   = { role: "system" };
+type UserMessage     = { role: "user" };
+export type AssistantMessage = { role: "assistant"; tool_calls: ToolCall[] };
+export type ToolMessage      = { role: "tool"; tool_call_id: string };
+
+export type MessageAddedEvent = {
+  msg: "MessageAdded";
+  message: MessageBase &
+    (SystemMessage | UserMessage | AssistantMessage | ToolMessage);
+};
+```
+
+MoonBit: [`event/event.mbt`](../../event/event.mbt#L53)
+
+```mbt
+MessageAdded(@ai.Message)
+```
+
+This is emitted whenever a new message is appended to the conversation
+history. The UI currently:
+
+- Ignores `system`, `assistant`, and `tool` messages when rendering events,
+  because they are better visualized via `RequestCompleted` and
+  `PostToolCall`.
+- Renders `user` messages as chat bubbles in the conversation timeline.
+
+JSON encoding:
+
+```jsonc
+{
+  "msg": "MessageAdded",
+  "message": {
+    "role": "user" | "system" | "assistant" | "tool",
+    "content": [
+      { "type": "text", "text": "..." }
+    ],
+    // for assistant / tool messages only
+    "tool_calls": [ /* optional tool calls, OpenAI‑style */ ],
+    "tool_call_id": "call_123" // for role === "tool"
+  }
+}
+```

--- a/docs/events/MessageUnqueued.md
+++ b/docs/events/MessageUnqueued.md
@@ -1,0 +1,31 @@
+# `MessageUnqueuedEvent`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L51)
+
+```ts
+type MessageUnqueuedEvent = {
+  msg: "MessageUnqueued";
+  message: { id: string };
+};
+```
+
+MoonBit: [`event/event.mbt`](../../event/event.mbt#L55)
+
+```mbt
+MessageUnqueued(id~ : @uuid.Uuid)
+```
+
+Emitted when a previously queued message (see `QueuedMessage`) is removed
+from the pending queue by the daemon. The UI uses `message.id` to remove the
+corresponding entry from `Task.inputQueue`.
+
+JSON encoding:
+
+```jsonc
+{
+  "msg": "MessageUnqueued",
+  "message": {
+    "id": "queued-message-id"
+  }
+}
+```

--- a/docs/events/PostConversation.md
+++ b/docs/events/PostConversation.md
@@ -1,0 +1,27 @@
+# `PostConversationEvent`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L56)
+
+```ts
+type PostConversationEvent = {
+  msg: "PostConversation";
+};
+```
+
+MoonBit: [`event/event.mbt`](../../event/event.mbt#L42)
+
+```mbt
+PostConversation
+```
+
+Signals that the daemon has finished processing a conversation. As of today
+the core UI does not render this event specially, but it is part of the
+`TaskEvent` union for future use.
+
+JSON encoding:
+
+```jsonc
+{
+  "msg": "PostConversation"
+}
+```

--- a/docs/events/PostToolCall.md
+++ b/docs/events/PostToolCall.md
@@ -1,0 +1,295 @@
+# `PostToolCallEvent`
+
+All `PostToolCall` events share a common base and then specialize per tool
+name:
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L147)
+
+```ts
+type PostToolCallBase = {
+  msg: "PostToolCall";
+  tool_call: ToolCall;
+  text: string;       // human‑readable rendering of the tool result
+  result?: unknown;   // machine‑readable result (tool‑specific)
+  error?: string;     // optional error description
+};
+
+export type PostToolCallEvent = PostToolCallBase &
+  | ExecuteCommandTool
+  | ListFilesTool
+  | ReadFileTool
+  | MetaWriteToFileTool
+  | UnknownTool;
+```
+
+MoonBit: [`event/event.mbt`](../../event/event.mbt#L73)
+
+```mbt
+PostToolCall(
+  @ai.ToolCall,
+  result~ : Result[Json, Json],
+  rendered~ : String,
+)
+```
+
+The UI behavior:
+
+- When a `PostToolCall` is received, it searches backwards in the event list
+  for a `PreToolCall` with the same `tool_call.id` and replaces it. This keeps
+  the UI timeline compact (“input” → “output” for a given tool call).
+- If no matching `PreToolCall` is found, the `PostToolCall` is simply appended
+  to the event list.
+
+JSON encoding:
+
+```jsonc
+// Successful tool call
+{
+  "msg": "PostToolCall",
+  "tool_call": {
+    "id": "call_123",
+    "type": "function",
+    "function": { "name": "read_file", "arguments": "{...}" }
+  },
+  "name": "read_file",
+  "result": { /* tool‑specific payload, see below */ },
+  "text": "Read 42 lines from README.md"
+}
+
+// Failed tool call
+{
+  "msg": "PostToolCall",
+  "tool_call": { /* same as above */ },
+  "name": "read_file",
+  "error": { /* JSON error payload */ },
+  "text": "Error: file not found"
+}
+```
+
+Tool‑specific shapes are described in the next section.
+
+The following are specializations of `PostToolCallEvent` used by the UI to
+render richer visualizations.
+
+## `ExecuteCommandTool` – `execute_command`
+
+TypeScript definition: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L79).
+
+```ts
+export type ExecuteCommandTool = {
+  name: "execute_command";
+  result: [
+    "Completed",
+    {
+      command: string;
+      status: number;         // process exit code
+      stdout: string;         // captured stdout
+      stderr: string;         // captured stderr
+      max_output_lines: number; // truncation hint
+    },
+  ];
+  error?: unknown;
+};
+```
+
+MoonBit definition: [`tools/execute_command/tool.mbt`](../../tools/execute_command/tool.mbt#L9).
+
+```mbt
+pub enum CommandResult {
+  Completed(
+    command~ : String,
+    status~ : Int,
+    stdout~ : String,
+    stderr~ : String,
+    max_output_lines~ : Int
+  )
+  TimedOut(
+    command~ : String,
+    timeout~ : Int,
+    stdout~ : String,
+    stderr~ : String,
+    max_output_lines~ : Int
+  )
+  Background(command~ : String, job_id~ : @job.Id)
+} derive(@json.FromJson, ToJson)
+```
+
+The UI:
+
+- Shows the command, exit code, and separate sections for stdout / stderr
+- Treats `status === 0` as success, anything else as error
+
+JSON encoding (`PostToolCall.result` for `execute_command`):
+
+```jsonc
+{
+  "name": "execute_command",
+  "result": [
+    "Completed",
+    {
+      "command": "moon test",
+      "status": 0,
+      "stdout": "...",
+      "stderr": "",
+      "max_output_lines": 2000
+    }
+  ],
+  "error": null
+}
+```
+
+## `ListFilesTool` – `list_files`
+
+TypeScript definition: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L94).
+
+```ts
+export type ListFilesTool = {
+  name: "list_files";
+  result: {
+    path: string; // directory that was listed
+    entries: { name: string; kind: string; is_hidden: boolean }[];
+    total_count: number;
+    file_count: number;
+    directory_count: number;
+  };
+};
+```
+
+MoonBit definition: [`tools/list_files/list_files.mbt`](../../tools/list_files/list_files.mbt#L1).
+
+```mbt
+///|
+/// File entry with metadata for enhanced list_files output
+priv struct FileEntry {
+  name : String
+  kind : String // "file", "directory", "symlink", etc.
+  size : Int? // Size in bytes for files, None for directories
+  is_hidden : Bool
+} derive(ToJson, FromJson)
+
+///|
+/// Enhanced list_files result with metadata
+struct ListFilesResult {
+  path : String
+  entries : Array[FileEntry]
+  total_count : Int
+  file_count : Int
+  directory_count : Int
+} derive(ToJson, FromJson)
+```
+
+Rendered as a scrollable list with per‑entry icons and summary badges for
+total / file / directory counts.
+
+JSON encoding (`PostToolCall.result` for `list_files`):
+
+```jsonc
+{
+  "name": "list_files",
+  "result": {
+    "path": ".", // listed directory
+    "entries": [
+      { "name": "README.md", "kind": "file", "is_hidden": false },
+      { "name": "src", "kind": "directory", "is_hidden": false }
+    ],
+    "total_count": 2,
+    "file_count": 1,
+    "directory_count": 1
+  }
+}
+```
+
+## `ReadFileTool` – `read_file`
+
+TypeScript definition: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L105).
+
+```ts
+export type ReadFileTool = {
+  name: "read_file";
+  result: {
+    path: string;      // file path
+    content: string;   // full file content
+    start_line: number;
+    end_line: number;
+  };
+};
+```
+
+MoonBit definition: [`tools/read_file/read_file.mbt`](../../tools/read_file/read_file.mbt#L2).
+
+```mbt
+///|
+struct ReadFileToolResult {
+  path : String
+  content : String
+  start_line : Int
+  end_line : Int
+} derive(ToJson, FromJson)
+```
+
+Displayed as a code block, with the language inferred from the file
+extension (fallback to `plaintext`).
+
+JSON encoding (`PostToolCall.result` for `read_file`):
+
+```jsonc
+{
+  "name": "read_file",
+  "result": {
+    "path": "README.md",
+    "content": "...full file contents...",
+    "start_line": 1,
+    "end_line": 200
+  }
+}
+```
+
+## `MetaWriteToFileTool` – `meta_write_to_file`
+
+TypeScript definition: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L115).
+
+```ts
+export type MetaWriteToFileTool = {
+  name: "meta_write_to_file";
+  result: {
+    path: string;     // file that was (or will be) written
+    message: string;  // human readable summary
+    diff?: string;    // optional unified diff string
+  };
+};
+```
+
+MoonBit definition: [`tools/meta_write_to_file/types.mbt`](../../tools/meta_write_to_file/types.mbt).
+
+```mbt
+///|
+pub struct MetaWriteToFileResult {
+  path : String
+  message : String
+  diff : String?
+  learning_prompt : String?
+} derive(ToJson, FromJson)
+```
+
+The UI shows `message` and, if present, renders `diff` as a syntax‑highlighted
+`diff` code block.
+
+JSON encoding (`PostToolCall.result` for `meta_write_to_file`):
+
+```jsonc
+{
+  "name": "meta_write_to_file",
+  "result": {
+    "path": "src/index.ts",
+    "message": "Planned edits for src/index.ts",
+    "diff": "--- a/src/index.ts\n+++ b/src/index.ts\n..."
+  }
+}
+```
+
+### Other tools
+
+Tools with unrecognized `name` values are still rendered using the generic
+`text` field of `PostToolCallEvent`, wrapped as a Markdown block. If a tool is
+named `"todo"`, the UI deliberately does **not** render a separate tool box,
+since todo updates are handled via `TodoUpdatedEvent` instead.

--- a/docs/events/PreToolCall.md
+++ b/docs/events/PreToolCall.md
@@ -1,0 +1,50 @@
+# `PreToolCallEvent`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L133)
+
+```ts
+type ToolCallFunction = {
+  name: string;
+  arguments: string; // JSON string
+};
+
+type ToolCall = {
+  id: string;
+  function: ToolCallFunction;
+};
+
+export type PreToolCallEvent = {
+  msg: "PreToolCall";
+  tool_call: ToolCall;
+};
+```
+
+MoonBit: [`event/event.mbt`](../../event/event.mbt#L62)
+
+```mbt
+PreToolCall(@ai.ToolCall)
+```
+
+Emitted right before a tool is executed. The UI:
+
+- Parses `tool_call.function.arguments` as JSON to show the structured input
+- Uses `tool_call.id` to later match the corresponding `PostToolCall` event
+
+JSON encoding:
+
+```jsonc
+{
+  "msg": "PreToolCall",
+  "tool_call": {
+    "id": "call_123",
+    "type": "function",
+    "function": {
+      "name": "read_file",
+      "arguments": "{ \"path\": \"README.md\" }"
+    }
+  },
+  // helper fields used mainly for debugging / logs
+  "name": "read_file",
+  "args": { "path": "README.md" } // or a JSON‑encoded string on parse error
+}
+```

--- a/docs/events/RequestCompleted.md
+++ b/docs/events/RequestCompleted.md
@@ -1,0 +1,49 @@
+# `RequestCompletedEvent`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L70)
+
+```ts
+export type RequestCompletedEvent = {
+  msg: "RequestCompleted";
+  message: {
+    content: string;       // final assistant text content
+    role: "assistant";
+    tool_calls: ToolCall[]; // tool calls (if any) used in this response
+  };
+};
+```
+
+MoonBit: [`event/event.mbt`](../../event/event.mbt#L94)
+
+```mbt
+RequestCompleted(usage~ : @ai.Usage?, message~ : @ai.Message)
+```
+
+Emitted when a chat completion finishes. The UI renders `message.content` as
+the assistant bubble in the conversation view.
+
+JSON encoding:
+
+```jsonc
+{
+  "msg": "RequestCompleted",
+  "usage": null | [
+    {
+      // OpenAI‑style token usage object (see @ai.Usage::to_openai)
+    }
+  ],
+  "message": {
+    "role": "assistant",
+    "content": [
+      { "type": "text", "text": "..." }
+    ],
+    "tool_calls": [
+      {
+        "id": "call_123",
+        "type": "function",
+        "function": { "name": "read_file", "arguments": "{...}" }
+      }
+    ]
+  }
+}
+```

--- a/docs/events/TodoUpdated.md
+++ b/docs/events/TodoUpdated.md
@@ -1,0 +1,52 @@
+# `TodoUpdatedEvent`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L42)
+
+```ts
+type TodoUpdatedEvent = {
+  msg: "TodoUpdated";
+  todo: {
+    todos: Todo[];
+    created_at: string;
+    updated_at: string;
+  };
+};
+```
+
+Whenever the daemon updates the agent TODO list (for example via a special
+tool), it emits `TodoUpdated`. The UI replaces its local `Task.todos` array
+with `todo.todos` and displays them in the “Agent TODOs” panel.
+
+MoonBit:
+
+- `TodoUpdated`: [`event/event.mbt`](../../event/event.mbt#L100),
+
+  ```mbt
+  /// Event triggered when the todo list is updated.
+  TodoUpdated(Json)
+  ```
+
+- `Items`: [`tools/todo/types.mbt`](../../tools/todo/types.mbt#L16),
+
+  ```mbt
+  pub struct Items {
+    todos : [Item]
+    created_at : String
+    updated_at : String
+  } derive(ToJson, FromJson, Eq)
+  ```
+
+- `Item`: See [Todo](../types/Todo.md).
+
+JSON encoding:
+
+```jsonc
+{
+  "msg": "TodoUpdated",
+  "todo": {
+    "todos": Todo[],
+    "created_at": "2024-01-01T00:00:00Z",
+    "updated_at": "2024-01-01T00:01:00Z"
+  }
+}
+```

--- a/docs/http.md
+++ b/docs/http.md
@@ -1,0 +1,230 @@
+# HTTP and SSE endpoints used by the UI
+
+The core React UI (`ui/core`) communicates with the daemon via plain HTTP and
+Server‑Sent Events (SSE). The canonical usage lives in
+`ui/core/src/features/api/apiSlice.ts`.
+
+All requests are prefixed with a base URL stored in the Redux `urlSlice`.
+Below we describe just the paths and payload shapes as seen from the UI.
+
+## `GET /task/:id`
+
+Request is not used.
+
+Response:
+
+```jsonc
+{
+  "task": TaskOverview
+}
+```
+
+- TypeScript: [`ui/core/src/features/api/apiSlice.ts#L48`](../ui/core/src/features/api/apiSlice.ts#L48)
+
+  On the UI side, this is called via `useTaskQuery` from `apiSlice`. The query
+  issues a `GET` to `task/:id`, then `onQueryStarted` reads `data.task` and
+  dispatches `setTask` so the Redux `tasksSlice` holds the latest `TaskOverview`.
+
+- MoonBit: [`cmd/daemon/daemon.mbt#L463`](../cmd/daemon/daemon.mbt#L463)
+
+  On the daemon side, [`Daemon::get_task`](../cmd/daemon/daemon.mbt#L463) looks
+  up the task by UUID, serializes it with
+  [`Task::to_json_object()`](../cmd/daemon/task.mbt#L110), [augments it with
+  `queued_messages()`](../cmd/daemon/daemon.mbt#L482), and [returns a `{ "task":
+  ... }` envelope](../cmd/daemon/daemon.mbt#L483) that matches the JSON shape
+  consumed by the UI.
+
+## `POST /task`
+
+Request body:
+
+```jsonc
+{
+  "name": string,          // task name, normally mirrors the first message
+  "model": string,         // model identifier (e.g. "anthropic/claude-sonnet-4.5")
+  "message": {             // initial user message
+    "role": "user",
+    "content": string
+  },
+  "cwd"?: string,          // optional working directory
+  "web_search": boolean    // whether web search is enabled for this task
+}
+```
+
+Response:
+
+```jsonc
+{
+  "task": TaskOverview
+}
+```
+
+- [TaskOverview](types.md#taskoverview)
+- TypeScript: [`ui/core/src/features/api/apiSlice.ts#L57`](../ui/core/src/features/api/apiSlice.ts#L57)
+- MoonBit: [`cmd/daemon/daemon.mbt#L198`](../cmd/daemon/daemon.mbt#L198)
+
+The React UI uses `useNewTaskMutation` to create tasks. The mutation builds the
+request body from the initial chat input (`message`), hard‑codes the model
+identifier, and optionally includes `cwd` and `web_search`. In MoonBit,
+`Daemon::create_task` decodes this JSON, spins up a per‑task Maria `Server`
+process, registers it in `by_id`/`by_cwd`, and returns the freshly created
+task’s overview as `{ "task": TaskOverview }`. The returned object is then fed
+back into the UI task list via RTK Query cache invalidation and the SSE
+synchronization described below.
+
+## `POST /task/:id/message`
+
+Request body:
+
+```jsonc
+{
+  "message": {
+    "role": "user",
+    "content": string
+  },
+  "web_search": boolean
+}
+```
+
+Response:
+
+```jsonc
+{
+  "id": string,      // server‑side ID of the queued/sent message
+  "queued": boolean  // true if the message was queued instead of sent
+}
+```
+
+- TypeScript: [`ui/core/src/features/api/apiSlice.ts#L81`](../ui/core/src/features/api/apiSlice.ts#L81)
+
+  On the TypeScript side, `usePostMessageMutation` issues a `POST` to
+  `task/:id/message` with an OpenAI‑style user message and a `web_search` flag.
+  The UI expects an `{ id, queued }` response; if `queued` is `true`, it pushes a
+  `QueuedMessage` `{ id, content }` into the per‑task `inputQueue` so the pending
+  input appears in the timeline. On the daemon side, the `POST /task/:id/message`
+  route is not handled directly; instead, it matches the `(method_, ["", "v1",
+  "task", id, .. paths])` arm in `Daemon::serve` and is passed to
+  `Daemon::forward_to_task`. That helper resolves the task by UUID, then proxies
+  the request to the per‑task HTTP server at
+  `http://localhost:<task.port>/v1/message`, streaming the original request body
+  through.
+
+- MoonBit: [`cmd/daemon/daemon.mbt#L640`](../cmd/daemon/daemon.mbt#L640),
+  [`cmd/server/server.mbt#L140`](../cmd/server/server.mbt#L140),
+  [`cmd/server/create_message.mbt#L42`](../cmd/server/create_message.mbt#L42)
+
+  Within the task process, `Server::serve_http` routes `POST /v1/message` to
+  `Server::create_message`. The `CreateMessageRequest` struct converts the
+  OpenAI‑style JSON into an internal `@ai.Message` (via
+  `@ai.Message::from_openai`) and optional `web_search` flag. `create_message`
+  enqueues this request onto the agent’s internal `message_queue`, obtains the
+  assigned message `id` and whether it started processing immediately (`queued ==
+  false`), and returns `{ "id": id, "queued": queued }`. Downstream, when the
+  agent later starts processing a queued message, it emits a `MessageUnqueued`
+  task event over SSE; the UI’s `taskEvents` listener sees this and removes the
+  corresponding `QueuedMessage` entry from `Task.inputQueue`.
+
+## `POST /task/:id/cancel`
+
+- TypeScript: [`ui/core/src/features/api/apiSlice.ts#L98`](../ui/core/src/features/api/apiSlice.ts#L98)
+
+  The React UI calls `usePostCancelMutation` with a `taskId` when the user hits
+  the cancel button. This results in a `POST` to `task/:id/cancel`, but the actual
+  body of the response is ignored; receiving either data or an error is treated as
+  confirmation that the in‑flight generation has stopped, and the task’s `Status`
+  is moved back to `"idle"` on the next SSE update.
+
+- MoonBit: [`cmd/daemon/daemon.mbt#L640`](../cmd/daemon/daemon.mbt#L640),
+  [`cmd/server/server.mbt#L164`](../cmd/server/server.mbt#L164),
+  [`cmd/server/server.mbt#L300`](../cmd/server/server.mbt#L300)
+
+  The daemon does not implement this path directly; it is
+  matched by the `(method_, ["", "v1", "task", id, .. paths])` arm and forwarded
+  by `Daemon::forward_to_task` as a proxied request to `POST /v1/cancel` on the
+  per‑task server. Inside the task process, `Server::serve_http` routes
+  `/v1/cancel` to `Server::cancel_maria`, which checks for an active Maria task,
+  calls `task.cancel()`, clears pending inputs via `maria.agent.clear_inputs()`,
+  and responds with any `pending_messages` that were dropped.
+
+## `GET /events` (SSE)
+
+The UI opens an `EventSource` on `${BASE_URL}/events` and subscribes to
+named events:
+
+- `daemon.tasks.synchronized` – full snapshot of tasks
+
+  ```jsonc
+  {
+    "tasks": TaskOverview[]
+  }
+  ```
+
+  ```ts
+  export type DaemonTaskSyncEvent = {
+    tasks: TaskOverview[];
+  };
+  ```
+
+- `daemon.task.changed` – single task updated or created
+
+  ```jsonc
+  {
+    "task": TaskOverview
+  }
+  ```
+
+  ```ts
+  export type DaemonTaskChangeEvent = {
+    task: TaskOverview;
+  };
+  ```
+
+These events are decoded into `DaemonTaskSyncEvent` and `DaemonTaskChangeEvent`
+respectively and used to keep the task list in sync.
+
+- TypeScript: [`ui/core/src/features/api/apiSlice.ts#L105`](../ui/core/src/features/api/apiSlice.ts#L105)
+
+  On the TypeScript side, `useEventsQuery` establishes a long‑lived
+  `EventSource` to `${BASE_URL}/events` inside `onCacheEntryAdded`. The listener
+  decodes the JSON payloads as `DaemonTaskSyncEvent` and `DaemonTaskChangeEvent`
+  and dispatches `setTasks` / `setTask`, keeping the Redux task list
+  synchronized with the daemon
+
+- MoonBit: [`cmd/daemon/daemon.mbt#L28`](../cmd/daemon/daemon.mbt#L28)
+
+  In MoonBit, `Daemon::get_events` sends a `daemon.tasks.synchronized` snapshot
+  with all current tasks when a connection is opened, then broadcasts
+  `daemon.task.changed` whenever individual tasks are created or updated. This
+  SSE stream is purely about task overviews; per‑task conversation state is
+  streamed via `/task/:id/events`.
+
+## `GET /task/:id/events` (SSE)
+
+For each active task view, the UI opens an `EventSource` on
+`${BASE_URL}/task/:id/events` and subscribes to the event type `"maria"`.
+
+Each event payload is JSON that matches the `TaskEvent` union described in the
+next section. The UI de‑duplicates events using their numeric `id` and uses the
+event sequence to render the conversation timeline.
+
+- TypeScript: [`ui/core/src/features/api/apiSlice.ts#L142`](../ui/core/src/features/api/apiSlice.ts#L142)
+
+  In the UI, `useTaskEventsQuery` uses `onCacheEntryAdded` to open an
+  `EventSource` to `/task/:id/events` for each active task view. Incoming events
+  of type `"maria"` are parsed as `TaskEvent` and fed into `pushEventForTask` or
+  `removeFromInputQueueForTask`, which updates the per‑task event timeline and
+  queued‑message state.
+
+- MoonBit: [`cmd/daemon/daemon.mbt#L640`](../cmd/daemon/daemon.mbt#L640),
+  [`cmd/server/server.mbt#L166`](../cmd/server/server.mbt#L166),
+  [`cmd/server/server.mbt#L324`](../cmd/server/server.mbt#L324)
+
+  On the daemon side, requests to `/task/:id/events` are again routed through
+  [`Daemon::forward_to_task`](../cmd/daemon/daemon.mbt#L640), which proxies them
+  to [`GET /v1/events`](../cmd/server/server.mbt#L166) on the per‑task Maria
+  `Server`. There, [`Server::get_events`](../cmd/server/server.mbt#L324) sends
+  an initial
+  [`maria.queued_messages.synchronized`](../cmd/server/server.mbt#L331) event
+  followed by an SSE stream of `OutgoingEvent` values (filtered to hide some
+  low‑level tokens and subagent tool events) under the `maria` event name. These
+  `OutgoingEvent` payloads are exactly what the UI’s `TaskEvent` union models.

--- a/docs/types.md
+++ b/docs/types.md
@@ -1,0 +1,10 @@
+# Core Types
+
+This document describes the JSON / TypeScript types that the Maria UI uses
+to talk to the daemon and to host environments (web, VS Code, Electron).
+
+- [`Message`](types/Message.md)
+- [`QueuedMessage`](types/QueuedMessage.md)
+- [`TaskOverview`](types/TaskOverview.md)
+- [`Todo`](types/Todo.md)
+- [`Status`](types/Status.md)

--- a/docs/types/Message.md
+++ b/docs/types/Message.md
@@ -1,0 +1,203 @@
+# `Message`
+
+Conversation messages are modeled slightly differently in the UI and daemon,
+but both sides agree on an OpenAI‑style JSON shape at the HTTP / SSE
+boundaries.
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L156)
+
+```ts
+type MessageContentPart = { text: string };
+
+type MessageBase = {
+  content: MessageContentPart[] | string;
+};
+
+type SystemMessage = {
+  role: "system";
+};
+
+type UserMessage = {
+  role: "user";
+};
+
+export type AssistantMessage = {
+  role: "assistant";
+  tool_calls: ToolCall[];
+};
+
+export type ToolMessage = {
+  role: "tool";
+  tool_call_id: string;
+};
+
+export type MessageAddedEvent = {
+  msg: "MessageAdded";
+  message: MessageBase &
+    (SystemMessage | UserMessage | AssistantMessage | ToolMessage);
+};
+
+export type RequestCompletedEvent = {
+  msg: "RequestCompleted";
+  message: {
+    content: string;
+    role: "assistant";
+    tool_calls: ToolCall[];
+  };
+};
+```
+
+On the UI side:
+
+- `MessageAddedEvent` is emitted for each message appended to the
+  conversation. The UI currently renders only `role: "user"` entries as chat
+  bubbles; `assistant` and `tool` messages are better represented via
+  `RequestCompletedEvent` and `PostToolCallEvent`.
+- `RequestCompletedEvent.message` represents the final assistant turn for a
+  completion, with `content` already flattened to a single string and
+  `tool_calls` mirroring the underlying OpenAI tool call array.
+
+MoonBit (`ai` package): [`ai/message.mbt`](../../ai/message.mbt),
+[`ai/convert.mbt`](../../ai/convert.mbt)
+
+```mbt
+pub enum Message {
+  User(String)
+  System(String)
+  Assistant(String, tool_calls~ : Array[ToolCall])
+  Tool(String, tool_call_id~ : String)
+}
+
+pub struct ToolCall {
+  id : String
+  name : String
+  arguments : String?
+}
+
+pub struct Usage {
+  input_tokens : Int
+  output_tokens : Int
+  total_tokens : Int
+  cache_read_tokens : Int?
+}
+```
+
+The daemon uses `@ai.Message` as its canonical in‑memory representation of
+conversation turns. Helper constructors like `user_message`, `system_message`,
+`assistant_message`, and `tool_message` are used throughout the agent to build
+messages, for example in `Agent::add_message` and `Agent::queue_message`
+[`agent/agent.mbt`](../../agent/agent.mbt).
+
+There is a dedicated conversion layer between `@ai.Message` and OpenAI‑style
+wire types defined in the `internal/openai` package:
+
+MoonBit (`ai` ↔ `internal/openai` conversions):
+
+- `Message::to_openai(self : Message) -> @openai.ChatCompletionMessageParam`
+- `Message::from_openai(param : @openai.ChatCompletionMessageParam) -> Message`
+- `Message::from_openai_response(msg : @openai.ChatCompletionMessage) -> Message`
+- `ToolCall::to_openai(self : ToolCall) -> @openai.ChatCompletionMessageToolCall`
+- `ToolCall::from_openai_tool_call(tc : @openai.ChatCompletionMessageToolCall) -> ToolCall`
+- `Usage::to_openai(self : Usage) -> @openai.CompletionUsage`
+- `Usage::from_openai(u : @openai.CompletionUsage) -> Usage`
+
+The `internal/openai` package
+([`internal/openai/types.mbt`](../../internal/openai/types.mbt),
+[`internal/openai/json.mbt`](../../internal/openai/json.mbt),
+[`internal/openai/ai.mbt`](../../internal/openai/ai.mbt)) defines the full set of
+OpenAI‑compatible request/response types (`ChatCompletionMessageParam`,
+`ChatCompletionMessage`, `Request`, `ChatCompletion`, `CompletionUsage`, etc.)
+and their JSON encoders/decoders. These types are used whenever the daemon
+actually serializes or parses JSON for the upstream model APIs.
+
+JSON encoding
+
+At the UI boundary, conversation messages always use OpenAI chat-completion
+shapes. The UI only relies on a subset of the full schema:
+
+```jsonc
+// System message
+{
+  "role": "system",
+  "content": "You are a helpful assistant."
+}
+
+// User message
+{
+  "role": "user",
+  "content": "Write a unit test for foo()"
+}
+
+// Assistant message without tools
+{
+  "role": "assistant",
+  "content": "Here is a test you can use..."
+}
+
+// Assistant message with tool calls
+{
+  "role": "assistant",
+  "content": [
+    { "type": "text", "text": "Let me inspect the file first." }
+  ],
+  "tool_calls": [
+    {
+      "id": "call_123",
+      "type": "function",
+      "function": {
+        "name": "read_file",
+        "arguments": "{ \"path\": \"README.md\" }"
+      }
+    }
+  ]
+}
+
+// Tool message (tool output fed back to the model)
+{
+  "role": "tool",
+  "content": "...tool output rendered as text...",
+  "tool_call_id": "call_123"
+}
+```
+
+Notes:
+
+- `content` may be either a plain string or an array of text parts
+  (`[{ "type": "text", "text": string }]`). The UI normalizes this into
+  `MessageContentPart[] | string`.
+- `tool_calls` only appears on assistant messages; the UI surfaces it on
+  `AssistantMessage.tool_calls` and in `RequestCompletedEvent.message`.
+- `tool_call_id` only appears on tool messages; the UI maps it to
+  `ToolMessage.tool_call_id`.
+
+These message objects are then wrapped by higher-level event envelopes that
+the UI listens to over SSE:
+
+```jsonc
+// From /task/:id/events (SSE "maria" event)
+{
+  "msg": "MessageAdded",
+  "message": { /* one of the message shapes above */ }
+}
+
+{
+  "msg": "RequestCompleted",
+  "usage": null | [ { /* token usage */ } ],
+  "message": { /* assistant message shape with tool_calls */ }
+}
+```
+
+Queued messages surfaced via
+`maria.queued_messages.synchronized`/`GET /v1/queued_messages` follow the same
+pattern, but wrapped with an `id` field:
+
+```jsonc
+{
+  "id": "queued-message-id",
+  "message": { /* one of the message shapes above */ }
+}
+```
+
+All other message-related JSON that the UI sees (HTTP `POST /task` initial
+message, `POST /task/:id/message`, SSE task events) is a direct reuse of these
+shapes.

--- a/docs/types/QueuedMessage.md
+++ b/docs/types/QueuedMessage.md
@@ -1,0 +1,45 @@
+# `QueuedMessage`
+
+`QueuedMessage` is not part of the public API between the UI and daemon, but is
+used both internally by the UI and daemon to model queued messages.
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L4)
+
+```ts
+export type QueuedMessage = {
+  id: string;
+  content: string;
+};
+```
+
+MoonBit:
+
+- `(@uuid.Uuid, Bool)` tuple in
+  [`cmd/server/server.mbt`](../../cmd/server/server.mbt#L12) to represent queued
+  message IDs
+
+- [`MessageQueued`](../../event/event.mbt#L57) /
+  [`MessageUnqueued`](../../event/event.mbt#L55) variants of `OutgoingEvent` in
+  [`event/event.mbt`](../../event/event.mbt#L36) to signal queued message changes
+
+- [`QueuedMessage`](../../agent/agent.mbt#L2) struct in
+  [`agent/agent.mbt`](../../agent/agent.mbt) to represent queued messages for
+  communication between server and agent.
+
+  ```mbt
+  pub struct QueuedMessage {
+    id : @uuid.Uuid
+    message : @ai.Message
+    web_search : Bool
+  }
+  ```
+
+JSON encoding: *not serialized directly*.
+
+When the user sends messages while a task is still `"generating"`, the daemon
+may choose to enqueue them instead of interrupting the current run. The UI
+stores those as `QueuedMessage` entries in a per‑task queue and surfaces them
+in the input panel.
+
+The daemon notifies the UI that a queued message has been consumed via a
+`MessageUnqueued` task event.

--- a/docs/types/Status.md
+++ b/docs/types/Status.md
@@ -1,0 +1,32 @@
+# `Status`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L16)
+
+```ts
+export type Status = "idle" | "generating";
+```
+
+MoonBit: [`cmd/server/status.mbt`](../../cmd/server/status.mbt)
+
+```mbt
+pub(all) enum Status {
+  Idle
+  Busy
+}
+```
+
+JSON encoding:
+
+```jsonc
+"idle" | "generating"
+```
+
+The UI treats a task as either:
+
+- `"idle"` – no model call is currently in flight
+- `"generating"` – the daemon is actively processing / streaming a response
+
+The `Status` is attached to `TaskOverview` and is updated via:
+
+- HTTP endpoints (e.g. creating a task)
+- SSE events like `daemon.task.changed` (see below)

--- a/docs/types/TaskOverview.md
+++ b/docs/types/TaskOverview.md
@@ -1,0 +1,56 @@
+# `TaskOverview`
+
+TypeScript: Defined in
+[`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L18). Also used in
+`ui/core/src/features/api/apiSlice.ts` (HTTP client) and in SSE payloads emitted
+by the daemon.
+
+```ts
+export type TaskOverview = {
+  id: string;
+  name: string;
+  status: Status;
+  created: number; // ms since epoch
+  cwd: string; // absolute path on the daemon host
+};
+```
+
+MoonBit:
+
+- `Task`: Defined in [`cmd/daemon/task.mbt`](../../cmd/daemon/task.mbt#L1).
+
+  ```mbt
+  priv struct Task {
+    name : String?
+    id : @uuid.Uuid
+    cwd : String
+    port : Int
+    mut status : @server.Status
+    created : Int64
+    web_search : Bool
+  }
+  ```
+
+- `@server.Status`: See [Status](../../types/Status.md).
+
+JSON:
+
+```json
+{
+  "name": "example" | null,
+  "id": "123e4567-e89b-12d3-a456-426614174000",
+  "cwd": "/tmp/example",
+  "port": 8080,
+  "status": "idle",
+  "created": 0,
+  "web_search": true,
+}
+```
+
+`TaskOverview` is the compact representation used:
+
+- In task lists (all frontends)
+- In daemon → UI synchronization events
+
+It does **not** include conversation history or todos; those live in
+per‑task state on the UI side.

--- a/docs/types/Todo.md
+++ b/docs/types/Todo.md
@@ -1,0 +1,68 @@
+# `Todo`
+
+TypeScript: [`ui/core/src/lib/types.ts`](../../ui/core/src/lib/types.ts#L120)
+
+```ts
+export type Todo = {
+  content: string;
+  created_at: string; // ISO timestamp
+  id: string;
+  priority: "High" | "Medium" | "Low";
+  status: "Pending" | "Completed" | "InProgress";
+  updated_at: string; // ISO timestamp
+};
+```
+
+MoonBit:
+
+- `Item`: [`tools/todo/types.mbt`](../../tools/todo/types.mbt#L37)
+
+  ```mbt
+  priv struct Item {
+    content : String
+    created_at : String
+    id : String
+    notes : String?
+    priority : Priority
+    status : Status
+    updated_at : String
+  }
+  ```
+
+- `Priority` enum: [`tools/todo/types.mbt`](../../tools/todo/types.mbt#L23)
+
+  ```mbt
+  priv enum Priority {
+    High
+    Medium
+    Low
+  }
+  ```
+
+- `Status` enum: [`tools/todo/types.mbt`](../../tools/todo/types.mbt#L30)
+
+  ```mbt
+  priv enum Status {
+    Pending
+    Completed
+    InProgress
+  }
+  ```
+
+JSON encoding (single todo item):
+
+```jsonc
+{
+  "content": "Write tests",
+  "created_at": "2024-01-01T00:00:00Z",
+  "id": "todo-1",
+  "priority": "High",          // "High" | "Medium" | "Low"
+  "status": "Pending",         // "Pending" | "Completed" | "InProgress"
+  "updated_at": "2024-01-01T00:00:00Z"
+}
+```
+
+The daemon emits updates via `TodoUpdated` task events (see `event/event.mbt`).
+Todos are managed by the daemon and mirrored into the UI via `TodoUpdated`
+task events (see below). The UI treats the daemon as the source of truth and
+does not mutate todo fields client‑side.


### PR DESCRIPTION
This PR adds comprehensive documentation for the Maria JS/TypeScript API in `js-api.md`.

The doc:

- Defines core shared types (Status, TaskOverview, Todo, Message, etc.) as used by the UI and daemon.
- Shows the mapping between TypeScript definitions, MoonBit structs/enums, and their JSON encodings.
- Describes how these types flow through HTTP endpoints and SSE events across web, Electron, and VS Code frontends.
- This should serve as the source of truth for anyone implementing new frontends or tools that integrate with the Maria daemon, making it easier to keep UI/daemon contracts consistent.

Review focus

- Check that the documented type shapes and field names match the current implementations in `types.ts`, `event.mbt`, and related files.
- Confirm the JSON examples and status/priority enums align with what the daemon actually emits.
- Call out any missing or outdated types you rely on so we can include them in this doc.