### PR TITLE
docs(httpx): document public APIs

### DIFF
--- a/internal/httpx/README.mbt.md
+++ b/internal/httpx/README.mbt.md
@@ -1,0 +1,123 @@
+# HTTPX Package
+
+The `httpx` package provides a small, composable HTTP toolkit for building
+servers on top of `@http.Server`. It includes:
+
+- A lightweight `RequestReader`/`ResponseWriter` pair
+- A method- and path-based router
+- JSON request/response helpers
+- Static file serving
+- CORS and Server-Sent Events (SSE) helpers
+
+## Quick Start
+
+### Minimal JSON API Server
+
+The following example shows how to expose a simple JSON endpoint using
+`Router`, `JsonRequestReader`, and `JsonResponseWriter`:
+
+```moonbit check
+///|
+struct ExampleRequest {
+  name : String
+  description : String
+} derive(ToJson, @json.FromJson)
+```
+
+```moonbit check
+///|
+enum ExampleResponse {
+  Ok(ExampleRequest)
+} derive(ToJson)
+```
+
+```moonbit test(async)
+///|
+let router = @httpx.Router::new()
+
+// Register a POST /task handler that reads and writes JSON
+router.add_handler(Post, "/task", (r, w) => {
+  let r = @httpx.JsonRequestReader::new(r)
+  let w = @httpx.JsonResponseWriter::new(w)
+  let task : ExampleRequest = r.read()
+  w.write_header(@status.Ok)
+  let res = ExampleResponse::Ok(task)
+  w.write(res)
+})
+
+// Start the HTTP server with the router
+let server = @httpx.Server::new("[::1]", 0)
+
+// Tests to verify the /task endpoint
+@async.with_task_group(group => {
+  // Start the server with CORS enabled
+  group.spawn_bg(
+    () => server.serve(@httpx.cors(router.handler())),
+    no_wait=true,
+  )
+  let (r, b) = @httpx.post_json("http://localhost:\{server.port()}/task", {
+    "name": "Example Task",
+    "description": "This is an example task.",
+  })
+  @json.inspect(r.code, content=@status.Ok.to_json())
+  @json.inspect(b.json(), content=[
+    "Ok",
+    { "name": "Example Task", "description": "This is an example task." },
+  ])
+})
+```
+
+### Router and File Server
+
+You can combine the router with `FileServer` to serve static files and dynamic
+routes from the same HTTP server:
+
+```moonbit test(async)
+let file_server = @httpx.FileServer::new("cmd/server")
+
+// Fallback to file server when no route matches
+let router = @httpx.Router::new()
+router.add_handler(Get, "/hello", (_, w) => {
+  w.write_header(@status.Ok)
+  w.write("Hello, world! from Router Handler\n")
+})
+router.set_not_found_handler((r, w) => file_server.handle(r, w))
+let server = @httpx.Server::new("[::1]", 0)
+
+// Start the server and test both the dynamic route and static file serving
+@async.with_task_group(group => {
+  group.spawn_bg(() => server.serve(router.handler()), no_wait=true)
+  let (r, b) = @http.get("http://localhost:\{server.port()}/hello")
+  @json.inspect(r.code, content=@status.Ok.to_json())
+  @json.inspect(b.text(), content="Hello, world! from Router Handler\n")
+  let (r, _) = @http.get("http://localhost:\{server.port()}/")
+  @json.inspect(r.code, content=@status.Ok.to_json())
+})
+```
+
+### Enabling CORS
+
+The `cors` middleware adds permissive CORS headers to all responses:
+
+```moonbit test(async)
+let file_server = @httpx.FileServer::new("cmd/server")
+let router = @httpx.Router::new()
+router.add_handler(Get, "/hello", (_, w) => {
+  w.write_header(@status.Ok)
+  w.write("Hello, world! from Router Handler\n")
+})
+router.set_not_found_handler((r, w) => file_server.handle(r, w))
+let server = @httpx.Server::new("[::1]", 0)
+@async.with_task_group(group => {
+  group.spawn_bg(
+    () => server.serve(@httpx.cors(router.handler())),
+    no_wait=true,
+  )
+  let (r, b) = @http.get("http://localhost:\{server.port()}/hello")
+  @json.inspect(r.code, content=@status.Ok.to_json())
+  @json.inspect(r.headers["access-control-allow-origin"], content="*")
+  @json.inspect(r.headers["access-control-allow-methods"], content="*")
+  @json.inspect(r.headers["access-control-allow-headers"], content="*")
+  @json.inspect(b.text(), content="Hello, world! from Router Handler\n")
+})
+```

--- a/internal/httpx/README.md
+++ b/internal/httpx/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/internal/httpx/cors.mbt
+++ b/internal/httpx/cors.mbt
@@ -1,4 +1,8 @@
 ///|
+/// Simple CORS middleware that allows all origins, methods and headers.
+///
+/// This is suitable for development or trusted environments. For production
+/// deployments, consider tightening the allowed origins and methods.
 pub let cors : Middleware = (k : Handler) => (r, w) => {
   w
   .header()
@@ -15,9 +19,11 @@ pub let cors : Middleware = (k : Handler) => (r, w) => {
 }
 
 ///|
-// Real world usage example
-// find all usage of `@http.post` in the codebase
-// and replace it with `@httpx.post_json`
+/// Convenience helper mirroring `@http.post` for JSON bodies.
+///
+/// Real world usage example: find all usages of `@http.post` in the
+/// codebase and replace them with `@httpx.post_json` to make the
+/// intent explicit.
 pub async fn post_json(
   uri : String,
   body : Json,

--- a/internal/httpx/event_stream.mbt
+++ b/internal/httpx/event_stream.mbt
@@ -1,9 +1,15 @@
 ///|
+/// Server-Sent Events (SSE) response writer.
+///
+/// `EventStreamWriter` configures the underlying `ResponseWriter` for
+/// `text/event-stream` responses and provides helpers for sending events in
+/// SSE format.
 pub struct EventStreamWriter {
   w : ResponseWriter
 }
 
 ///|
+/// Wraps a `ResponseWriter` and configures headers for SSE.
 pub fn EventStreamWriter::new(w : ResponseWriter) -> EventStreamWriter {
   w.header().set("Content-Type", "text/event-stream")
   w.header().set("Cache-Control", "no-cache")
@@ -14,6 +20,7 @@ pub fn EventStreamWriter::new(w : ResponseWriter) -> EventStreamWriter {
 }
 
 ///|
+/// Writes the HTTP status line and headers for the event stream response.
 pub async fn EventStreamWriter::write_header(
   self : EventStreamWriter,
   status : Int,
@@ -22,6 +29,14 @@ pub async fn EventStreamWriter::write_header(
 }
 
 ///|
+/// Writes a single SSE event to the response stream.
+///
+/// Parameters:
+///
+/// * `id` : Optional event ID.
+/// * `event` : Optional event type.
+/// * `data` : Optional data payload written as-is.
+/// * `flush` : When true (default), flushes the response after the event.
 pub async fn EventStreamWriter::write_event(
   self : EventStreamWriter,
   id? : String,

--- a/internal/httpx/file_server.mbt
+++ b/internal/httpx/file_server.mbt
@@ -1,4 +1,8 @@
 ///|
+/// Simple static file server rooted at a given directory.
+///
+/// `FileServer` exposes a middleware and handler that can be mounted into a
+/// router to serve static assets such as HTML, JS and CSS files.
 struct FileServer {
   path : String
   middleware : Middleware
@@ -6,21 +10,28 @@ struct FileServer {
 }
 
 ///|
+/// Returns the current handler used to serve static files.
 pub fn FileServer::handler(self : FileServer) -> Handler {
   self.handler
 }
 
 ///|
+/// Returns the middleware that wraps the static file handler.
 pub fn FileServer::middleware(self : FileServer) -> Middleware {
   self.middleware
 }
 
 ///|
+/// Returns the filesystem path that this file server is rooted at.
 pub fn FileServer::path(self : FileServer) -> StringView {
   self.path.view()
 }
 
 ///|
+/// Creates a new file server rooted at the given directory.
+///
+/// The resulting middleware only serves `GET` requests and falls back to the
+/// downstream handler when a file does not exist.
 pub fn FileServer::new(path : StringView) -> FileServer {
   let self_path = path.to_string()
   let middleware : Middleware = k => (r, w) => {
@@ -75,6 +86,7 @@ pub fn FileServer::new(path : StringView) -> FileServer {
 }
 
 ///|
+/// Handles a single HTTP request using the configured static file handler.
 pub async fn FileServer::handle(
   self : FileServer,
   r : RequestReader,
@@ -84,6 +96,9 @@ pub async fn FileServer::handle(
 }
 
 ///|
+/// Overrides the handler used when a requested file is not found.
+///
+/// The handler is wrapped by the file server's middleware.
 pub async fn FileServer::set_not_found_handler(
   self : FileServer,
   handler : Handler,

--- a/internal/httpx/handler.mbt
+++ b/internal/httpx/handler.mbt
@@ -1,2 +1,6 @@
 ///|
+/// Represents an asynchronous HTTP handler function.
+///
+/// A `Handler` receives a `RequestReader` for reading the incoming request
+/// and a `ResponseWriter` for sending the HTTP response back to the client.
 pub(all) struct Handler(async (RequestReader, ResponseWriter) -> Unit)

--- a/internal/httpx/header.mbt
+++ b/internal/httpx/header.mbt
@@ -1,4 +1,8 @@
 ///|
+/// Mutable HTTP header collection.
+///
+/// `Header` stores header names and values as strings and provides helpers
+/// for setting, merging and appending values.
 struct Header(Map[String, String])
 
 ///|
@@ -12,21 +16,30 @@ pub impl Show for Header with output(self : Header, logger : &Logger) -> Unit {
 }
 
 ///|
+/// Creates an empty header map.
 pub fn Header::new() -> Header {
   Header({})
 }
 
 ///|
+/// Sets a header to the given value, replacing any existing value.
 pub fn Header::set(self : Header, key : String, value : String) -> Unit {
   self.0[key] = value
 }
 
 ///|
+/// Merges a map of headers into this header collection.
+///
+/// Existing keys are overwritten by the values from `config`.
 pub fn Header::config(self : Header, config : Map[String, String]) -> Unit {
   self.0.merge_in_place(config)
 }
 
 ///|
+/// Adds a value to a potentially multi-valued header.
+///
+/// If the header already exists, the new value is appended using
+/// `", "` as a separator, otherwise it is set as-is.
 pub fn Header::add(self : Header, key : String, value : String) -> Unit {
   match self.0.get(key) {
     Some(existing) => self.0[key] = "\{existing}, \{value}"

--- a/internal/httpx/json.mbt
+++ b/internal/httpx/json.mbt
@@ -1,5 +1,9 @@
 ///|
-struct JsonRequestReader(RequestReader)
+/// Wrapper around `RequestReader` for JSON-based HTTP APIs.
+///
+/// `JsonRequestReader` provides helpers for decoding the request body as
+/// raw JSON or into strongly-typed values via `@json.FromJson`.
+pub struct JsonRequestReader(RequestReader)
 
 ///|
 pub suberror JsonError {
@@ -7,6 +11,14 @@ pub suberror JsonError {
 }
 
 ///|
+/// Constructs a new JSON error payload from a lower-level error.
+///
+/// Parameters:
+///
+/// * `code` : HTTP status code to return.
+/// * `error` : Underlying error that triggered this JSON error.
+/// * `message` : Optional human-friendly error message.
+/// * `data` : Optional structured error payload.
 pub fn JsonError::new(
   code : Int,
   error : Error,
@@ -17,6 +29,7 @@ pub fn JsonError::new(
 }
 
 ///|
+/// Writes the JSON error response to the given `ResponseWriter`.
 pub async fn JsonError::write(self : JsonError, w : ResponseWriter) -> Unit {
   let JsonError(code~, error=_, message~, data~) = self
   w.header().set("Content-Type", "application/json")
@@ -28,11 +41,15 @@ pub async fn JsonError::write(self : JsonError, w : ResponseWriter) -> Unit {
 }
 
 ///|
+/// Creates a JSON-aware request reader from a plain `RequestReader`.
 pub fn JsonRequestReader::new(r : RequestReader) -> JsonRequestReader {
   r
 }
 
 ///|
+/// Reads the entire request body and parses it as JSON.
+///
+/// Raises `JsonError` with status `400` for invalid UTF-8 or JSON payloads.
 pub async fn JsonRequestReader::read_json(self : JsonRequestReader) -> Json {
   let data = self.body.read_all().binary()
   let text : String = @encoding/utf8.decode(data) catch {
@@ -46,6 +63,9 @@ pub async fn JsonRequestReader::read_json(self : JsonRequestReader) -> Json {
 }
 
 ///|
+/// Deserializes the request body into a value of type `T`.
+///
+/// Raises `JsonError` with status `400` when JSON decoding fails.
 pub async fn[T : @json.FromJson] JsonRequestReader::read(
   self : JsonRequestReader,
 ) -> T {
@@ -57,15 +77,18 @@ pub async fn[T : @json.FromJson] JsonRequestReader::read(
 }
 
 ///|
+/// JSON response writer that automatically sets the `Content-Type` header.
 struct JsonResponseWriter(ResponseWriter)
 
 ///|
+/// Wraps a `ResponseWriter` and sets `Content-Type: application/json`.
 pub fn JsonResponseWriter::new(w : ResponseWriter) -> JsonResponseWriter {
   w.header().set("Content-Type", "application/json")
   w
 }
 
 ///|
+/// Writes only the status line and headers for a JSON response.
 pub async fn JsonResponseWriter::write_header(
   self : JsonResponseWriter,
   code : Int,
@@ -82,6 +105,7 @@ pub async fn JsonResponseWriter::write_json(
 }
 
 ///|
+/// Serializes a value to JSON and writes it as the response body.
 pub async fn[T : ToJson] JsonResponseWriter::write(
   self : JsonResponseWriter,
   json : T,

--- a/internal/httpx/method.mbt
+++ b/internal/httpx/method.mbt
@@ -1,4 +1,5 @@
 ///|
+/// HTTP request methods supported by the `httpx` router.
 pub(all) enum Method {
   Get
   Head
@@ -32,6 +33,7 @@ pub impl Show for Method with output(self : Method, out : &Logger) -> Unit {
 }
 
 ///|
+/// Array containing all supported HTTP methods.
 pub let methods : Array[Method] = [
   Method::Get,
   Method::Head,
@@ -60,6 +62,7 @@ fn Method::from_async_http(method_ : @http.RequestMethod) -> Method {
 }
 
 ///|
+/// Converts a `Method` into the corresponding `@http.RequestMethod` value.
 pub fn Method::to_http(self : Method) -> @http.RequestMethod {
   match self {
     Method::Get => @http.RequestMethod::Get

--- a/internal/httpx/middleware.mbt
+++ b/internal/httpx/middleware.mbt
@@ -1,15 +1,24 @@
 ///|
+/// Middleware wrapper that transforms one `Handler` into another.
+///
+/// Middlewares can be chained to build reusable HTTP processing pipelines
+/// (logging, authentication, CORS, routing, etc.).
 pub(all) struct Middleware((Handler) -> Handler)
 
 ///|
+/// Default handler that responds with `404 Not Found`.
 pub let not_found : Handler = (_, w) => w.write_header(@status.NotFound)
 
 ///|
+/// Chains two middlewares together.
+///
+/// The `other` middleware is applied first, followed by `self`.
 pub fn Middleware::chain(self : Middleware, other : Middleware) -> Middleware {
   Middleware(k => (self.0)((other.0)(k)))
 }
 
 ///|
+/// Executes the middleware chain using the default `not_found` handler.
 pub async fn Middleware::handle(
   self : Middleware,
   r : RequestReader,
@@ -19,6 +28,7 @@ pub async fn Middleware::handle(
 }
 
 ///|
+/// Returns a `Handler` produced by applying this middleware to `not_found`.
 pub fn Middleware::handler(self : Middleware) -> Handler {
   self(not_found)
 }

--- a/internal/httpx/pkg.generated.mbti
+++ b/internal/httpx/pkg.generated.mbti
@@ -53,7 +53,9 @@ pub fn Header::set(Self, String, String) -> Unit
 pub impl Show for Header
 pub impl ToJson for Header
 
-type JsonRequestReader
+pub struct JsonRequestReader(RequestReader)
+#deprecated
+pub fn JsonRequestReader::inner(Self) -> RequestReader
 pub fn JsonRequestReader::new(RequestReader) -> Self
 pub async fn[T : @json.FromJson] JsonRequestReader::read(Self) -> T
 pub async fn JsonRequestReader::read_json(Self) -> Json

--- a/internal/httpx/request.mbt
+++ b/internal/httpx/request.mbt
@@ -1,7 +1,15 @@
 ///|
+/// Lightweight wrapper around an incoming HTTP request.
+///
+/// `RequestReader` exposes the request body as an `@io.Reader`, the HTTP
+/// method, the request path and any path variables captured by the router.
 pub struct RequestReader {
+  /// Reader for the request body stream.
   body : &@io.Reader
+  /// HTTP method of the request.
   method_ : Method
+  /// Full request path as received by the server.
   path : StringView
+  /// Route parameters extracted from the matched path pattern.
   vars : Map[StringView, StringView]
 }

--- a/internal/httpx/response.mbt
+++ b/internal/httpx/response.mbt
@@ -1,4 +1,8 @@
 ///|
+/// HTTP response writer used by `httpx` handlers.
+///
+/// `ResponseWriter` buffers response headers until the first write, then
+/// streams the body to the underlying `@http.ServerConnection`.
 struct ResponseWriter {
   mut sent : Bool
   header : Header
@@ -11,11 +15,20 @@ fn ResponseWriter::new(conn : @http.ServerConnection) -> ResponseWriter {
 }
 
 ///|
+/// Returns the mutable header map for this response.
+///
+/// Headers can be configured before the status line is written.
 pub fn ResponseWriter::header(self : ResponseWriter) -> Header {
   self.header
 }
 
 ///|
+/// Sends the HTTP status line and all configured headers.
+///
+/// Parameters:
+///
+/// * `code` : HTTP status code to send.
+/// * `reason` : Optional reason phrase, defaults to `httpx::reason(code)`.
 pub async fn ResponseWriter::write_header(
   self : ResponseWriter,
   code : Int,
@@ -55,6 +68,7 @@ pub impl @io.Writer for ResponseWriter with write_reader(
 }
 
 ///|
+/// Flushes any buffered response data to the client.
 pub async fn ResponseWriter::flush(self : ResponseWriter) -> Unit {
   self.conn.flush()
 }

--- a/internal/httpx/router.mbt
+++ b/internal/httpx/router.mbt
@@ -1,4 +1,5 @@
 ///|
+/// Internal routing entry storing the handler and captured parameter names.
 priv struct Route {
   handle : Handler
   names : Array[StringView]
@@ -106,6 +107,10 @@ fn Layer::route(
 }
 
 ///|
+/// HTTP request router with method- and path-based dispatch.
+///
+/// `Router` matches incoming requests against registered path patterns and
+/// methods, populating `RequestReader.vars` with any captured parameters.
 struct Router {
   layer : Layer
   allow : MethodSet
@@ -114,6 +119,10 @@ struct Router {
 }
 
 ///|
+/// Creates a new, empty router with a default 404 handler.
+///
+/// The router installs a middleware that handles `OPTIONS *` requests and
+/// populates `Allow` headers based on the registered routes.
 pub fn Router::new() -> Router {
   let layer = Layer::new()
   let allow = MethodSet::new()
@@ -157,6 +166,13 @@ pub fn Router::new() -> Router {
 }
 
 ///|
+/// Registers a new handler for the given HTTP method and path pattern.
+///
+/// Parameters:
+///
+/// * `method_` : HTTP method to match.
+/// * `path` : Route path starting with `/`, optionally containing
+///   `{name}` segments which are exposed via `RequestReader.vars`.
 pub fn Router::add_handler(
   self : Router,
   method_ : Method,
@@ -173,6 +189,9 @@ pub fn Router::add_handler(
 }
 
 ///|
+/// Sets a custom handler to be used when no route matches.
+///
+/// The handler is wrapped by the router's middleware chain.
 pub fn Router::set_not_found_handler(self : Router, handler : Handler) -> Unit {
   self.handler = (self.middleware)(handler)
 }

--- a/internal/httpx/server.mbt
+++ b/internal/httpx/server.mbt
@@ -1,15 +1,30 @@
 ///|
+/// Thin wrapper around `@http.Server` providing a simpler API.
+///
+/// `Server` binds to the given host/port and exposes helpers for querying
+/// the bound port and running a `httpx` handler loop.
 struct Server {
   server : @http.Server
   port : Int
 }
 
 ///|
+/// Closes the underlying HTTP server and stops accepting new connections.
 pub fn Server::close(self : Server) -> Unit {
   self.server.close()
 }
 
 ///|
+/// Creates a new HTTP server bound to `host:port`.
+///
+/// Parameters:
+///
+/// * `host` : Hostname or IP address to bind.
+/// * `port` : Preferred TCP port (0 lets the OS choose a free port).
+/// * `dual_stack` : Enable IPv4/IPv6 dual-stack when supported.
+/// * `reuse_addr` : Enable address reuse on the socket.
+///
+/// The actual bound port can be retrieved via `Server::port`.
 pub fn Server::new(
   host : String,
   port : Int,
@@ -26,6 +41,7 @@ pub fn Server::new(
 }
 
 ///|
+/// Returns the TCP port the server is currently listening on.
 pub fn Server::port(self : Server) -> Int {
   self.port
 }

--- a/internal/httpx/status.mbt
+++ b/internal/httpx/status.mbt
@@ -1,4 +1,9 @@
 ///|
+/// Returns the standard reason phrase for a given HTTP status code.
+///
+/// For known codes this uses the mappings from `httpx/status` and
+/// `httpx/reason`. For unknown codes it falls back to a generic description
+/// based on the status class.
 pub fn reason(status : Int) -> String {
   match status {
     @status.Continue => @reason.Continue


### PR DESCRIPTION
## Summary

Docs-only update to the `internal/httpx` package that documents the public HTTP surface and adds an examples-driven README with runnable snippets.

## Changes

- **Docstrings for public APIs**
  - Added descriptive doc blocks for key types and functions:
    - `Handler`, `RequestReader`, `ResponseWriter`
    - `Router` (including `add_handler` and `set_not_found_handler`)
    - `Server` (lifecycle and configuration)
    - `Header` and header helpers
    - JSON helpers: `JsonRequestReader`, `JsonResponseWriter`, `JsonError`
    - Middleware primitives: `Middleware`, `not_found`, `cors`
    - Utilities: `FileServer`, `EventStreamWriter`, `reason`, `Method` helpers
  - Docstrings follow the existing `agent` package style (high-level summary + optional Parameters section) so they show up cleanly in `moon doc`.

- **New README for httpx**
  - Added `internal/httpx/README.mbt.md` documenting:
    - Overview of the httpx toolkit (router, request/response helpers, JSON, static files, CORS, SSE).
    - **Minimal JSON API server** example using `Router`, `JsonRequestReader`, `JsonResponseWriter`, `Server`, and `post_json`.
    - **Router + FileServer** composition example for serving both dynamic routes and static content.
    - **CORS** example wrapping a router with `httpx.cors` and asserting headers.
  - Added `internal/httpx/README.md` as a thin shim pointing to `README.mbt.md` to support tools that expect `README.md`.

- **Interface tweaks**
  - Promoted `JsonRequestReader` to a public struct in the generated interface and added a deprecated `inner` accessor to preserve backward compatibility.