### PR TITLE
docs(c): add docstring & README

### DIFF
--- a/internal/c/README.mbt.md
+++ b/internal/c/README.mbt.md
@@ -1,0 +1,84 @@
+# C Interop Package
+
+The `@c` package provides low-level building blocks for interpolating with C
+code and raw memory from MoonBit. It focuses on a small, well-defined surface
+area:
+
+- An opaque `Pointer[T]` type for unmanaged memory
+- Null pointer modelling via `Null` and `Pointer::null`
+- Thin wrappers around `malloc` / `free`
+- Bindings for `memcpy` and `strlen`
+- An emergency `exit` helper built on top of C `_exit`
+
+Most of these APIs are inherently unsafe: they bypass MoonBit's usual safety
+checks and require careful manual reasoning about lifetimes, ownership, and
+pointer validity.
+
+## Pointer Basics
+
+```moonbit test
+// Allocate space for a single Int
+let ptr : @c.Pointer[Int] = @c.malloc(8)
+// Write a value through the pointer
+ptr.store(42)
+// Read the value back
+let value = ptr.load()
+assert_eq(value, 42)
+// Always free what you allocate
+@c.free(ptr)
+```
+
+The `Pointer[T]` type is opaque and does not carry any automatic lifetime
+management. It provides helpers like:
+
+- `Pointer::null()` / `Pointer::is_null()`
+- Indexing via `ptr[i]` powered by the `Load`/`Store` traits
+
+## Working with C Strings
+
+The `strlen` binding exposes the standard C string length routine. It expects a
+null-terminated sequence of bytes and returns the length without the
+terminating `0` byte:
+
+```moonbit test
+///|
+let s : Pointer[Byte] = @c.malloc(6)
+s[0] = 'h'
+s[1] = 'e'
+s[2] = 'l'
+s[3] = 'l'
+s[4] = 'o'
+s[5] = 0
+@json.inspect(strlen(s), content="5")
+@c.free(s)
+```
+
+## Memory Copy with `memcpy`
+
+`memcpy` copies a fixed number of bytes between two pointer regions. The
+regions must **not** overlap:
+
+```moonbit test
+let src : Pointer[Byte] = malloc(4)
+let dst : Pointer[Byte] = malloc(4)
+src[0] = 1
+src[1] = 2
+src[2] = 3
+src[3] = 4
+@c.memcpy(dst.cast(), src.cast(), 4)
+assert_eq(dst[0], 1)
+assert_eq(dst[3], 4)
+@c.free(src)
+@c.free(dst)
+```
+
+## Process Exit
+
+The `exit` helper exposes C `_exit` as a last-resort termination primitive:
+
+```moonbit test
+@c.exit(0)
+```
+
+This is intended for low-level runtime code and should generally not be used in
+high-level application logic.

--- a/internal/c/README.md
+++ b/internal/c/README.md
@@ -1,0 +1,1 @@
+README.mbt.md

--- a/internal/c/exit.mbt
+++ b/internal/c/exit.mbt
@@ -1,7 +1,16 @@
 ///|
+/// Low-level wrapper around the C `_exit` function.
+///
+/// This function terminates the current process immediately without running
+/// any cleanup handlers. It is used by `exit` and should not be called
+/// directly from user code in most cases.
 extern "c" fn _exit(status : Int) = "exit"
 
 ///|
+/// Terminates the current process with the given exit status.
+///
+/// This function never returns; it delegates to the C `_exit` function and
+/// then calls `abort` as a safeguard if control ever comes back.
 pub fn[T] exit(status : Int) -> T {
   _exit(status)
   abort("exit should never return")

--- a/internal/c/malloc.mbt
+++ b/internal/c/malloc.mbt
@@ -1,15 +1,29 @@
 ///|
+/// Low-level wrapper around the C `malloc` function.
+///
+/// `c_malloc` allocates `size` bytes of raw memory and returns a pointer to
+/// uninitialized storage. The returned memory must eventually be freed via
+/// `c_free` (or `free`).
 extern "c" fn c_malloc(size : UInt64) -> Pointer[Unit] = "moonbit_maria_c_malloc"
 
 ///|
+/// Allocates `size` bytes of memory and casts it to `Pointer[T]`.
+///
+/// This is a thin, unsafe wrapper around `c_malloc`: the caller is
+/// responsible for choosing an appropriate `T`, initializing the memory, and
+/// eventually freeing it with `free`.
 pub fn[T] malloc(size : UInt64) -> Pointer[T] {
   c_malloc(size).cast()
 }
 
 ///|
+/// Low-level wrapper around the C `free` function.
 extern "c" fn c_free(ptr : Pointer[Unit]) = "moonbit_maria_c_free"
 
 ///|
+/// Releases memory previously allocated with `malloc` / `c_malloc`.
+///
+/// After calling `free`, the given pointer must not be dereferenced again.
 pub fn[T] free(ptr : Pointer[T]) -> Unit {
   c_free(ptr.cast())
 }

--- a/internal/c/memcpy.c
+++ b/internal/c/memcpy.c
@@ -3,6 +3,6 @@
 
 MOONBIT_FFI_EXPORT
 void
-moonbit_c_memcpy(void *dest, void *src, uint64_t len) {
+moonbit_maria_c_memcpy(void *dest, void *src, uint64_t len) {
   memcpy(dest, src, len);
 }

--- a/internal/c/memcpy.mbt
+++ b/internal/c/memcpy.mbt
@@ -1,4 +1,8 @@
 ///|
+/// Copies `len` bytes from `src` to `dest` using C `memcpy`.
+///
+/// The source and destination regions must not overlap. This is a thin
+/// wrapper around the standard C library function and is inherently unsafe.
 pub extern "c" fn memcpy(
   dest : Pointer[Byte],
   src : Pointer[Byte],

--- a/internal/c/memcpy_test.mbt
+++ b/internal/c/memcpy_test.mbt
@@ -1,0 +1,14 @@
+///|
+test "memcpy" {
+  let src : @c.Pointer[Byte] = @c.malloc(16)
+  for i in 0..<16 {
+    src[i] = i.to_byte()
+  }
+  defer @c.free(src)
+  let dst : @c.Pointer[Byte] = @c.malloc(16)
+  for i in 0..<16 {
+    dst[i] = 0
+  }
+  defer @c.free(dst)
+  @c.memcpy(dst, src, 16)
+}

--- a/internal/c/pointer.mbt
+++ b/internal/c/pointer.mbt
@@ -1,44 +1,61 @@
 ///|
+/// Opaque raw pointer type used for C interop.
+///
+/// `Pointer[T]` represents an unmanaged memory address that is assumed to
+/// point to a value (or array of values) of type `T`. All operations on
+/// pointers are inherently unsafe and should be used with care.
 #external
 #alias(Ptr)
 pub type Pointer[_]
 
 ///|
+/// Unsafely reinterprets a pointer as pointing to a different element type.
+///
+/// This does not change the underlying address; only the static type
+/// information is updated. The caller must ensure that the cast is valid.
 pub fn[T, U] Pointer::cast(self : Pointer[T]) -> Pointer[U] = "%identity"
 
 ///|
+/// Low-level binding used to check whether a pointer is null.
 extern "c" fn Pointer::_is_null(ptr : Pointer[Unit]) -> Bool = "moonbit_maria_c_is_null"
 
 ///|
+/// Returns `true` when the pointer is equal to the null pointer.
 pub fn[T] Pointer::is_null(self : Pointer[T]) -> Bool {
   self.cast()._is_null()
 }
 
 ///|
+/// Returns the canonical null pointer value.
 extern "c" fn Pointer::_null() -> Pointer[Unit] = "moonbit_maria_c_null"
 
 ///|
+/// Creates a null pointer of type `Pointer[T]`.
 pub fn[T] Pointer::null() -> Pointer[T] {
   Pointer::_null().cast()
 }
 
 ///|
+/// Compares two raw pointers for address equality.
 pub extern "c" fn Pointer::op_equal(
   self : Pointer[Unit],
   other : Pointer[Unit],
 ) -> Bool = "moonbit_maria_c_pointer_equal"
 
 ///|
+/// Implements structural equality for pointers via `op_equal`.
 pub impl[T] Eq for Pointer[T] with equal(self : Pointer[T], other : Pointer[T]) -> Bool {
   self.cast().op_equal(other.cast())
 }
 
 ///|
+/// Indexing helper that loads the `index`-th element via `Load`.
 pub fn[T : Load] Pointer::op_get(self : Pointer[T], index : Int) -> T {
   T::load(self, index)
 }
 
 ///|
+/// Indexing helper that stores into the `index`-th element via `Store`.
 pub fn[T : Store] Pointer::op_set(
   self : Pointer[T],
   index : Int,
@@ -48,11 +65,13 @@ pub fn[T : Store] Pointer::op_set(
 }
 
 ///|
+/// Loads a value of type `T` from this pointer at `offset`.
 pub fn[T : Load] Pointer::load(self : Pointer[T], offset? : Int = 0) -> T {
   T::load(self, offset)
 }
 
 ///|
+/// Stores a value of type `T` into this pointer at `offset`.
 pub fn[T : Store] Pointer::store(
   self : Pointer[T],
   offset? : Int = 0,
@@ -62,11 +81,16 @@ pub fn[T : Store] Pointer::store(
 }
 
 ///|
+/// Trait for types that can be loaded from raw memory.
+///
+/// Implementations of `Load` define how to read a value of the given type
+/// from a `Pointer[Self]` at a specific element offset.
 pub(open) trait Load {
   load(Pointer[Self], Int) -> Self
 }
 
 ///|
+/// Raw C bindings used by `Load` implementations for primitive types.
 extern "c" fn moonbit_c_load_byte(
   pointer : Pointer[Byte],
   offset : Int,
@@ -163,6 +187,7 @@ pub impl Load for Double with load(pointer : Pointer[Double], offset : Int) -> D
 }
 
 ///|
+/// Raw C bindings used by `Store` implementations for primitive types.
 extern "c" fn moonbit_c_store_byte(
   pointer : Pointer[Byte],
   offset : Int,
@@ -226,6 +251,10 @@ extern "c" fn moonbit_c_store_double(
 ) -> Unit = "moonbit_maria_c_store_double"
 
 ///|
+/// Trait for types that can be stored into raw memory.
+///
+/// Implementations of `Store` define how to write a value of the given type
+/// into a `Pointer[Self]` at a specific element offset.
 trait Store {
   store(Pointer[Self], Int, Self) -> Unit
 }

--- a/internal/c/strlen.mbt
+++ b/internal/c/strlen.mbt
@@ -1,2 +1,6 @@
 ///|
+/// Returns the length of a C-style null-terminated string.
+///
+/// The pointer must reference a sequence of bytes terminated by `0`. The
+/// result does not include the terminating null byte.
 pub extern "c" fn strlen(str : Pointer[Byte]) -> UInt64 = "moonbit_maria_c_strlen"


### PR DESCRIPTION
add C interop docs and pointer API comments

## Summary

- Add `internal/c/README.mbt.md` describing the `@c` interop package, pointer basics, C string handling with `strlen`, memory copying with `memcpy`, and the low-level `exit` helper, with example snippets.
- Add `internal/c/README.md` as a simple redirect to `README.mbt.md` to integrate with existing documentation tooling.
- Enrich `internal/c/exit.mbt`, `malloc.mbt`, `memcpy.mbt`, `pointer.mbt`, and `strlen.mbt` with detailed docstrings explaining semantics, safety expectations, and usage patterns.