### PR TITLE
fix(agent): remove close to avoid unread `None` event.

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -228,9 +228,9 @@ fn Agent::cancel(agent : Agent) -> Unit {
 pub async fn Agent::start(agent : Agent) -> Unit {
   @async.with_task_group(group => {
     // Start the event target in background to handle async event processing
-    group.spawn_bg(() => agent.event_target.start())
+    group.spawn_bg(() => agent.event_target.start(), no_wait=true)
     @async.with_task_group(group => {
-      group.add_defer(() => agent.event_target.close())
+      group.add_defer(() => agent.event_target.flush())
       // Signal the start of conversation
       agent.emit(PreConversation)
       while !(agent.input_queue.is_empty() && agent.pending_queue.is_empty()) {

--- a/event/event_target.mbt
+++ b/event/event_target.mbt
@@ -22,7 +22,7 @@ struct EventTarget {
   // TODO: Consider adding a `Closed` event variant instead of using `Event?`.
   // This would make the termination signal explicit in the type system rather
   // than using `None` as a sentinel value.
-  queue : @aqueue.Queue[OutgoingEvent?]
+  queue : @aqueue.Queue[OutgoingEvent]
   listeners : Array[async (OutgoingEvent) -> Unit]
 }
 
@@ -75,7 +75,7 @@ pub fn EventTarget::new() -> EventTarget {
 /// emitter.emit(PostConversation)
 /// ```
 pub fn EventTarget::emit(self : EventTarget, event : OutgoingEvent) -> Unit {
-  guard self.queue.try_put(Some(event)) else {
+  guard self.queue.try_put(event) else {
     abort("Event queue is full, cannot emit event")
   }
 }
@@ -140,9 +140,16 @@ pub fn EventTarget::add_listener(
 /// })
 /// ```
 pub async fn EventTarget::start(self : EventTarget) -> Unit {
-  while self.queue.get() is Some(event) {
+  while true {
+    let event = self.queue.get()
+    let errors = []
     for listener in self.listeners {
-      listener(event)
+      listener(event) catch {
+        error => errors.push(error)
+      }
+    }
+    if errors is [error, ..] {
+      raise error
     }
   }
 }
@@ -171,50 +178,9 @@ pub async fn EventTarget::start(self : EventTarget) -> Unit {
 /// and then call listeners outside of the loop to avoid racing?
 /// assuming listerns can take a long time
 pub async fn EventTarget::flush(self : EventTarget) -> Unit {
-  while self.queue.try_get() is Some(Some(event)) {
+  while self.queue.try_get() is Some(event) {
     for listener in self.listeners {
       listener(event)
     }
-  }
-}
-
-///|
-/// Gracefully closes the event target.
-///
-/// This method:
-/// 1. Flushes all remaining events (handling errors gracefully)
-/// 2. Sends a termination signal (`None`) to stop the `start()` loop
-///
-/// # Error Handling
-///
-/// If any listener throws an error during the final flush, the error is
-/// collected and re-raised after all events are processed. Only the first
-/// error is propagated.
-///
-/// # Panics
-///
-/// Aborts if unable to enqueue the termination signal.
-///
-/// # Example
-///
-/// ```moonbit no-check
-/// // Graceful shutdown
-/// emitter.close()
-/// // start() will now return
-/// ```
-pub async fn EventTarget::close(self : EventTarget) -> Unit {
-  let errors = []
-  while self.queue.try_get() is Some(Some(event)) {
-    for listener in self.listeners {
-      listener(event) catch {
-        error => errors.push(error)
-      }
-    }
-  }
-  guard self.queue.try_put(None) else {
-    abort("Event queue is full, cannot close")
-  }
-  if errors is [error, ..] {
-    raise error
   }
 }

--- a/event/event_test.mbt
+++ b/event/event_test.mbt
@@ -1,4 +1,20 @@
 ///|
+async test "EventTarget::flush" {
+  let event_target = @event.EventTarget::new()
+  let events : Array[@event.OutgoingEvent] = []
+  event_target.add_listener(event => events.push(event))
+  @async.with_task_group(group => {
+    let task = group.spawn(() => event_target.start(), allow_failure=true)
+    task.cancel()
+    let task = group.spawn(() => event_target.start(), allow_failure=true)
+    event_target.emit(TokenCounted(10))
+    event_target.flush()
+    task.cancel()
+  })
+  @json.inspect(events, content=[{ "msg": "TokenCounted", "token_count": 10 }])
+}
+
+///|
 fn redact_events(events : Array[@event.OutgoingEvent]) -> Array[Json] {
   events.map(event => event
     .to_json()

--- a/event/pkg.generated.mbti
+++ b/event/pkg.generated.mbti
@@ -26,7 +26,6 @@ pub impl @json.FromJson for Event
 
 type EventTarget
 pub fn EventTarget::add_listener(Self, async (OutgoingEvent) -> Unit) -> Unit
-pub async fn EventTarget::close(Self) -> Unit
 pub fn EventTarget::emit(Self, OutgoingEvent) -> Unit
 pub async fn EventTarget::flush(Self) -> Unit
 pub fn EventTarget::new() -> Self


### PR DESCRIPTION
### Summary

Fix a fairness issue in `EventTarget` by simplifying its lifecycle and relying on task cancellation instead of a cooperative `close` signal. Also adds regression coverage in `event_test.mbt`.

### Why the previous cooperative `close` was problematic

- `EventTarget.start` dequeued from an internal `@aqueue.Queue[@event.OutgoingEvent]` until it saw a `None` sentinel, which was used as a "close" signal.
- When the external task driving the target was cancelled, that `None` value could still be left enqueued.
- If `start()` was called again later, it would immediately (or very quickly) see the queued `None` and exit, even though there was no new cancellation request. This broke the expectation that a fresh `start()` call should process new events fairly and normally.

### Why we removed `close`

- By removing the explicit `close` method and the `None` sentinel, users of `EventTarget` now stop external event loops purely via task cancellation.
- This avoids leaving a stale `None` value in the queue, so each `start()` invocation behaves consistently and does not exit prematurely due to an old close signal.


### Testing

- `moon test -p moonbitlang/maria/event -f event_test.mbt -i 0 -u --target native`
