### PR TITLE
feat(daemon): graceful shutdown

### DIFF
--- a/cmd/daemon/README.md
+++ b/cmd/daemon/README.md
@@ -355,3 +355,7 @@ If failed, returns 500 Internal Server Error:
   },
 }
 ```
+
+### `POST /v1/shutdown`
+
+Shuts down the daemon server gracefully.

--- a/cmd/daemon/daemon.mbt
+++ b/cmd/daemon/daemon.mbt
@@ -594,6 +594,14 @@ pub async fn Daemon::serve(self : Daemon) -> Unit {
             (Get, ["", "v1", "task", id]) => self.get_task(id, w)
             (method_, ["", "v1", "task", id, .. paths]) =>
               self.forward_to_task(method_~, id~, paths~, r, w)
+            (Post, ["", "v1", "shutdown"]) => {
+              w.header().set("Content-Type", "application/json")
+              w.write_header(200)
+              let response : Json = {}
+              w.write(response.stringify())
+              w.flush()
+              group.return_immediately(())
+            }
             (Post, ["", "v1", "moonbit", "publish"]) =>
               publish_moonbit_module(r, w)
             (Get, ["", .. file]) =>


### PR DESCRIPTION
/cc @bzy-debug 

- Adds a `POST /v1/shutdown` endpoint that responds with 200 and then calls `group.return_immediately(())` so the daemon can exit cleanly.
- Responds with an empty JSON object and permissive CORS headers (`*` for origin/methods/headers); this matches existing patterns but we may want to document or tighten this if the endpoint is exposed outside trusted environments.
- README now documents `POST /v1/shutdown`; consider adding a note about expected auth (if any) and recommended client behavior around in-flight work before triggering shutdown.
