### PR TITLE
feat(maria): add fix_moonbit_warnings

### DIFF
--- a/agent/agent_tool.mbt
+++ b/agent/agent_tool.mbt
@@ -5,8 +5,8 @@ struct Tool {
 }
 
 ///|
-fn Tool::new(tool : @tool.AgentTool) -> Tool {
-  Tool::{ enabled: true, tool }
+fn Tool::new(tool : @tool.AgentTool, enabled? : Bool = true) -> Tool {
+  Tool::{ enabled, tool }
 }
 
 ///|
@@ -154,9 +154,13 @@ pub fn Agent::add_tools(agent : Agent, tools : Array[@tool.AgentTool]) -> Unit {
 ///
 /// * `agent` : The agent instance to add the tool to.
 /// * `tool` : The agent tool to register.
-fn Agent::add_agent_tool(agent : Agent, tool : @tool.AgentTool) -> Unit {
+fn Agent::add_agent_tool(
+  agent : Agent,
+  tool : @tool.AgentTool,
+  enabled? : Bool = true,
+) -> Unit {
   let desc = tool.desc()
-  agent.tools[desc.name] = Tool::new(tool)
+  agent.tools[desc.name] = Tool::new(tool, enabled~)
   agent.emit(ToolAdded(desc))
 }
 
@@ -171,8 +175,9 @@ fn Agent::add_agent_tool(agent : Agent, tool : @tool.AgentTool) -> Unit {
 pub fn[Output : ToJson + Show] Agent::add_tool(
   agent : Agent,
   tool : @tool.Tool[Output],
+  enabled? : Bool = true,
 ) -> Unit {
-  agent.add_agent_tool(tool.to_agent_tool())
+  agent.add_agent_tool(tool.to_agent_tool(), enabled~)
 }
 
 ///|

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -30,7 +30,7 @@ pub(all) struct Agent {
   // private fields
 }
 pub fn Agent::add_listener(Self, async (@event.OutgoingEvent) -> Unit) -> Unit
-pub fn[Output : ToJson + Show] Agent::add_tool(Self, @tool.Tool[Output]) -> Unit
+pub fn[Output : ToJson + Show] Agent::add_tool(Self, @tool.Tool[Output], enabled? : Bool) -> Unit
 pub fn Agent::add_tools(Self, Array[@tool.AgentTool]) -> Unit
 pub fn Agent::clear_inputs(Self) -> Array[QueuedMessage]
 pub fn Agent::close(Self) -> Unit

--- a/cmd/server/server_test.mbt
+++ b/cmd/server/server_test.mbt
@@ -700,6 +700,7 @@ async test "GET /v1/tools" (t : @test.Test) {
       "todo": { "enabled": true },
       "search_files": { "enabled": true },
       "meta_write_to_file": { "enabled": true },
+      "fix_moonbit_warnings": { "enabled": false },
     })
     let (r, b) = @httpx.post_json(
       "http://localhost:\{server.port()}/v1/enabled-tools",
@@ -717,6 +718,7 @@ async test "GET /v1/tools" (t : @test.Test) {
       "todo": { "enabled": true },
       "search_files": { "enabled": true },
       "meta_write_to_file": { "enabled": true },
+      "fix_moonbit_warnings": { "enabled": false },
     })
   })
 }

--- a/maria.mbt
+++ b/maria.mbt
@@ -42,6 +42,7 @@ pub async fn Maria::new(
     @search_files.new(agent.cwd).to_agent_tool(),
     @meta_write_to_file.new(agent).to_agent_tool(),
   ])
+  agent.add_tool(@fix_moonbit_warnings.new(agent), enabled=false)
   { logger, agent }
 }
 

--- a/moon.pkg.json
+++ b/moon.pkg.json
@@ -14,6 +14,7 @@
     "moonbitlang/maria/job",
     "moonbitlang/maria/tool",
     "moonbitlang/maria/tools/meta_write_to_file",
-    "moonbitlang/maria/ai"
+    "moonbitlang/maria/ai",
+    "moonbitlang/maria/tools/fix_moonbit_warnings"
   ]
 }


### PR DESCRIPTION
## Summary

This PR introduces a new `fix_moonbit_warnings` tool that automatically fixes MoonBit compiler warnings and errors using AI-powered code analysis and patching. Additionally, it enhances the agent framework by adding support for configurable tool enablement, allowing tools to be registered in a disabled state by default.

## Key Changes

### 🆕 New Feature: `fix_moonbit_warnings` Tool

A sophisticated tool that batch-processes MoonBit projects to automatically fix compiler warnings and errors:

**Core Functionality:**

- **Batch Processing**: Analyzes all files in a MoonBit project and identifies segments with warnings/errors
- **AI-Powered Fixing**: Spawns subagents to fix individual code segments using the MoonBit compiler's diagnostic feedback
- **Verification Loop**: Uses a `submit_moonbit_segment` tool to iteratively verify fixes until they compile without errors
- **Concurrent Processing**: Processes multiple files and segments concurrently with semaphore-based rate limiting (max 4 concurrent operations)
- **Timeout Protection**: Includes comprehensive timeout handling at multiple levels (2-8 minutes per segment, 80 minutes total)

**Workflow:**

1. Loads the MoonBit module and runs initial compilation checks
2. Identifies segments with warnings/errors
3. For each problematic segment, spawns a specialized subagent with:
   - The original code segment and diagnostics
   - A focused system prompt for MoonBit code fixing
   - The `submit_moonbit_segment` verification tool
4. Subagent iteratively fixes and verifies the code until it compiles
5. Successfully fixed segments are written back to the source files

**Tool Parameters:**

- `description`: Description of the changes/fixes to apply
- `project_path`: Path to the MoonBit project (moon.mod.json location)

**Current Limitations:**

- Does not support fixing code embedded in `.mbt.md` files
- Enabled by default as `false` (opt-in feature)

### 🔧 Enhanced Tool Registration API

Modified the agent framework to support optional tool enablement:

**Before:**

```moonbit
agent.add_tool(some_tool)
```

**After:**

```moonbit
agent.add_tool(some_tool, enabled=false)  // Register but disable by default
agent.add_tool(some_tool)                  // Default: enabled=true
```

**Implementation Details:**

- Added `enabled?: Bool = true` parameter to `Agent::add_tool()` and `Agent::add_agent_tool()`
- Modified `Tool::new()` constructor to accept `enabled?` parameter
- Updated interface in [agent/pkg.generated.mbti](agent/pkg.generated.mbti#L33)

## Files Modified

### Agent Framework

- **[agent/agent_tool.mbt](agent/agent_tool.mbt)** (+8 -5 lines)
  - Added `enabled?` parameter to tool registration methods
  - Modified `Tool::new()` to accept enablement state

- **[agent/pkg.generated.mbti](agent/pkg.generated.mbti)** (+1 -1 lines)
  - Updated public interface signature for `Agent::add_tool()`

### Tool Integration

- **[tools/fix_moonbit_warnings/tool.mbt](tools/fix_moonbit_warnings/tool.mbt)** (new file, 283 lines)
  - Complete implementation of the `fix_moonbit_warnings` tool
  - Includes subagent spawning, verification loop, and concurrent processing

- **[maria.mbt](maria.mbt#L45)** (+1 line)
  - Registered the new tool with `enabled=false`

- **[moon.pkg.json](moon.pkg.json)** (+1 line)
  - Added `moonbitlang/maria/tools/fix_moonbit_warnings` to imports

### Tests

- **[cmd/server/server_test.mbt](cmd/server/server_test.mbt)** (+2 lines)
  - Updated test expectations to include the new tool in disabled state

## Testing Notes

### Manual Testing

1. Test the `fix_moonbit_warnings` tool on a project with known warnings:

   ```bash
   # Ensure the project has some warnings
   moon check

   # Use Maria to fix them
   maria exec "Fix all warnings in the current project using fix_moonbit_warnings"
   ```

2. Verify that the tool is disabled by default:

   ```bash
   # Check enabled tools via API
   curl http://localhost:<port>/v1/tools
   # Confirm "fix_moonbit_warnings": { "enabled": false }
   ```

3. Test concurrent processing with projects containing multiple files with warnings

### Automated Tests

- Server tests updated to verify the tool appears in the disabled state
- All existing tests pass with the new tool registration API changes

## Breaking Changes

None. The `enabled?` parameter is optional with a default value of `true`, maintaining backward compatibility with existing code.

## Additional Notes

### Design Decisions

1. **Disabled by Default**: The tool is registered as disabled because it:
   - Makes significant automated code changes
   - Can be time-consuming for large projects (80 minute max timeout)
   - Spawns multiple subagents with AI inference costs
   - Should be explicitly opted-in by users

2. **Subagent Pattern**: Uses specialized subagents rather than inline fixing to:
   - Isolate the fixing logic with a focused system prompt
   - Provide iterative verification feedback
   - Enable concurrent processing of multiple segments
   - Maintain clean separation of concerns

3. **Timeout Strategy**: Multiple timeout layers ensure:
   - Individual segment fixes don't hang (8 minutes max)
   - Overall operation completes in reasonable time (80 minutes)
   - Resources are properly released on timeout

### Future Improvements

- Add support for `.mbt.md` files
- Expose concurrency limit as a parameter
- Add dry-run mode to preview changes
- Collect and report statistics on fix success rates
- Add configuration for timeout values
