### PR TITLE
refactor(daemon): public Task for {To,From}Json

### DIFF
--- a/cmd/daemon/daemon.mbt
+++ b/cmd/daemon/daemon.mbt
@@ -327,15 +327,14 @@ async fn Daemon::create_task(
     "[INFO] (Daemon) Received registration from task '\{id}' on port \{task_port}",
   )
   let created = self.clock.now() / 1_000
-  let task = Task::{
-    name: request.name,
-    id,
-    cwd,
-    port: task_port,
-    status: Idle,
-    created,
-    web_search: request.web_search is Some(true),
-  }
+  let task = Task::new(
+    name?=request.name,
+    id~,
+    cwd~,
+    port=task_port,
+    created~,
+    web_search=request.web_search is Some(true),
+  )
   // FIXME: The daemon does not ends anyway, so this cleanup code is never run.
   group.spawn_bg(() => {
     let exit_code = process.wait()
@@ -469,9 +468,8 @@ async fn Daemon::get_task(
       "error": { "code": -1, "message": "Task not found: \{id}" },
     })
   }
-  let task_json = task.to_json_object()
-  task_json["queued_messages"] = task.queued_messages().to_json()
-  let response : Json = { "task": task_json }
+  task.sync()
+  let response : Json = { "task": task }
   w.header().set("Content-Type", "application/json")
   w.write_header(200)
   w.write(response.stringify())

--- a/cmd/daemon/daemon_test.mbt
+++ b/cmd/daemon/daemon_test.mbt
@@ -608,13 +608,19 @@ async test "GET /v1/events" (t : @test.Test) {
               "name": null,
               "status": "generating",
               "web_search": false,
+              "queued_messages": [],
             },
           },
         },
         { "event": "daemon.task.changed" },
         {
           "data": {
-            "task": { "name": null, "status": "idle", "web_search": false },
+            "task": {
+              "name": null,
+              "status": "idle",
+              "web_search": false,
+              "queued_messages": [],
+            },
           },
         },
       ],

--- a/cmd/daemon/pkg.generated.mbti
+++ b/cmd/daemon/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/cmd/daemon"
 
 import(
+  "moonbitlang/core/json"
   "moonbitlang/maria/internal/uuid"
 )
 
@@ -17,6 +18,10 @@ type Daemon
 pub async fn Daemon::new(uuid? : @uuid.Generator, exec_path~ : String, port~ : Int, serve~ : String, cwd? : StringView, home? : StringView, lock? : Bool) -> Self?
 pub fn Daemon::port(Self) -> Int
 pub async fn Daemon::serve(Self) -> Unit
+
+type Task
+pub impl ToJson for Task
+pub impl @json.FromJson for Task
 
 // Type aliases
 

--- a/cmd/daemon/task.mbt
+++ b/cmd/daemon/task.mbt
@@ -1,12 +1,40 @@
 ///|
-priv struct Task {
+struct Task {
   name : String?
   id : @uuid.Uuid
   cwd : String
   port : Int
   mut status : @server.Status
+  queued_messages : Array[QueuedMessage]
   created : Int64
   web_search : Bool
+}
+
+///|
+fn Task::new(
+  name? : String,
+  id~ : @uuid.Uuid,
+  cwd~ : String,
+  port~ : Int,
+  created~ : Int64,
+  web_search~ : Bool,
+) -> Task {
+  Task::{
+    name,
+    id,
+    cwd,
+    port,
+    status: @server.Idle,
+    queued_messages: [],
+    created,
+    web_search,
+  }
+}
+
+///|
+async fn Task::sync(task : Task) -> Unit {
+  task.sync_status()
+  task.sync_queued_messages()
 }
 
 ///|
@@ -48,8 +76,8 @@ async fn Task::sync_status(task : Task) -> Unit {
 }
 
 ///|
-async fn Task::queued_messages(task : Task) -> Array[QueuedMessage] {
-  let ms = []
+async fn Task::sync_queued_messages(task : Task) -> Unit {
+  task.queued_messages.clear()
   let (r, b) = @http.get("http://localhost:\{task.port}/v1/queued-messages") catch {
     error =>
       raise json_error(500, "Internal Server Error", {
@@ -90,24 +118,141 @@ async fn Task::queued_messages(task : Task) -> Array[QueuedMessage] {
   }
   for m in queued_messages {
     guard m is { "id": String(id), "message": message, .. } else { continue }
-    ms.push({ id, message })
+    task.queued_messages.push({ id, message })
   }
-  ms
 }
 
 ///|
 priv struct QueuedMessage {
   id : String
   message : Json
-} derive(ToJson)
+} derive(ToJson, @json.FromJson)
 
 ///|
-impl ToJson for Task with to_json(self : Task) -> Json {
-  Json::object(self.to_json_object())
+pub impl @json.FromJson for Task with from_json(
+  json : Json,
+  json_path : @json.JsonPath,
+) -> Task {
+  guard json is Object(map) else {
+    raise @json.JsonDecodeError((json_path, "Task::from_json: expected object"))
+  }
+  let name = match map.get("name") {
+    Some([String(name)]) | Some(String(name)) => Some(name)
+    None | Some(Null) => None
+    Some(_) =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("name"), "Task::from_json: expected string or null"),
+      )
+  }
+  let id = match map.get("id") {
+    Some(String(id_str)) =>
+      @uuid.parse(id_str) catch {
+        error =>
+          raise @json.JsonDecodeError(
+            (
+              json_path.add_key("id"),
+              "Task::from_json: invalid UUID string: \{error}",
+            ),
+          )
+      }
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("id"), "Task::from_json: expected string"),
+      )
+  }
+  let cwd = match map.get("cwd") {
+    Some(String(cwd)) => cwd
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("cwd"), "Task::from_json: expected string"),
+      )
+  }
+  let port = match map.get("port") {
+    Some(Number(port, ..)) => port.to_int()
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("port"), "Task::from_json: expected number"),
+      )
+  }
+  let status = match map.get("status") {
+    Some(String(status_str)) =>
+      match status_str.to_lower() {
+        "idle" => @server.Idle
+        "generating" => @server.Busy
+        _ =>
+          raise @json.JsonDecodeError(
+            (
+              json_path.add_key("status"),
+              "Task::from_json: unknown status '\{status_str}'",
+            ),
+          )
+      }
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("status"), "Task::from_json: expected string"),
+      )
+  }
+  let web_search = match map.get("web_search") {
+    Some(True) => true
+    Some(False) => false
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("web_search"), "Task::from_json: expected bool"),
+      )
+  }
+  let created = match map.get("created") {
+    Some(Number(created_num, repr=None)) => {
+      guard created_num >= 0.0 else {
+        raise @json.JsonDecodeError(
+          (
+            json_path.add_key("created"),
+            "Task::from_json: created timestamp cannot be negative",
+          ),
+        )
+      }
+      created_num.to_int64()
+    }
+    Some(Number(_, repr=Some(created_str)) | String(created_str)) =>
+      @strconv.parse_int64(created_str) catch {
+        error =>
+          raise @json.JsonDecodeError(
+            (
+              json_path.add_key("created"),
+              "Task::from_json: invalid Int64 string: \{error}",
+            ),
+          )
+      }
+    _ =>
+      raise @json.JsonDecodeError(
+        (json_path.add_key("created"), "Task::from_json: expected number"),
+      )
+  }
+  let queued_messages = match map.get("queued_messages") {
+    Some(Array(qms)) => {
+      let ms = Array::new()
+      for i, qm_json in qms {
+        let qm : QueuedMessage = @json.from_json(
+          qm_json,
+          path=json_path.add_key("queued_messages").add_index(i),
+        )
+        ms.push(qm)
+      }
+      ms
+    }
+    None => []
+    _ =>
+      raise @json.JsonDecodeError(
+        (
+          json_path.add_key("queued_messages"),
+          "Task::from_json: expected array",
+        ),
+      )
+  }
+  Task::{ name, id, cwd, port, status, created, web_search, queued_messages }
 }
 
 ///|
-fn Task::to_json_object(self : Task) -> Map[String, Json] {
+pub impl ToJson for Task with to_json(self : Task) -> Json {
   {
     "name": self.name,
     "id": self.id.to_string(),
@@ -119,6 +264,7 @@ fn Task::to_json_object(self : Task) -> Map[String, Json] {
       repr=self.created.to_string(),
     ),
     "web_search": self.web_search,
+    "queued_messages": self.queued_messages,
   }
 }
 
@@ -130,6 +276,9 @@ test "Task::ToJson" {
     cwd: "/tmp/example",
     port: 8080,
     status: @server.Idle,
+    queued_messages: [
+      QueuedMessage::{ id: "msg1", message: { "text": "Hello" } },
+    ],
     created: 0,
     web_search: true,
   }
@@ -141,5 +290,6 @@ test "Task::ToJson" {
     "status": "idle",
     "created": 0,
     "web_search": true,
+    "queued_messages": [{ "id": "msg1", "message": { "text": "Hello" } }],
   })
 }

--- a/cmd/daemon/task_test.mbt
+++ b/cmd/daemon/task_test.mbt
@@ -1,0 +1,16 @@
+///|
+test "Task/roundtrip" {
+  let json : Json = {
+    "name": ["example"],
+    "id": "123e4567-e89b-12d3-a456-426614174000",
+    "cwd": "/tmp/example",
+    "port": 8080,
+    "status": "idle",
+    "created": 0,
+    "web_search": true,
+    "queued_messages": [{ "id": "msg1", "message": { "text": "Hello" } }],
+  }
+  let task : @daemon.Task = @json.from_json(json)
+  let roundtrip = task.to_json()
+  assert_eq(json, roundtrip)
+}


### PR DESCRIPTION
# Refactor: Make Task public with ToJson and FromJson implementations

## Summary

This PR refactors the `Task` structure in the daemon module by making it public and implementing comprehensive JSON serialization and deserialization. The changes improve the API design by consolidating task data synchronization and simplifying the task retrieval logic.

## Motivation

The previous implementation had several limitations:
1. The `Task` struct was private, limiting its reusability in other modules
2. JSON serialization was manual and incomplete - `queued_messages` were fetched separately and manually added to the JSON output
3. The task creation logic used direct struct initialization, making it verbose and prone to errors
4. No JSON deserialization support existed for `Task`, limiting flexibility for future features

## Refactors

### 1. Made Task Public with JSON Support
- Changed `Task` from `priv struct` to `struct`, making it publicly accessible
- Implemented `ToJson` trait for Task with complete serialization including `queued_messages`
- Implemented `FromJson` trait for Task with comprehensive validation and error handling
- Added `FromJson` implementation for `QueuedMessage` helper struct

### 2. Improved Task Data Management
- Added `queued_messages` field directly to the `Task` struct instead of fetching it separately
- Created `Task::new()` constructor function with named parameters for cleaner initialization
- Introduced `Task::sync()` function to consolidate synchronization of both status and queued messages
- Split synchronization logic into `sync_status()` and `sync_queued_messages()` methods

### 3. Simplified Daemon Logic
- Refactored `Daemon::create_task()` to use the new `Task::new()` constructor
- Simplified `Daemon::get_task()` to use `task.sync()` and direct JSON serialization
- Removed manual JSON manipulation (`to_json_object()` followed by adding `queued_messages`)
- Cleaner code flow: `task.sync()` → serialize entire task as JSON

### 4. Enhanced FromJson Implementation
- Comprehensive error handling with descriptive error messages
- Proper JSON path tracking for debugging
- Validation for all fields including:
  - UUID parsing with error propagation
  - Status string mapping to enum values
  - Int64 parsing for `created` timestamp
  - Array deserialization for `queued_messages`
  - Null handling for optional `name` field

## Changes

### Modified Files

**[cmd/daemon/daemon.mbt](cmd/daemon/daemon.mbt):**
- Replaced direct struct initialization with `Task::new()` constructor
- Simplified `get_task()` to use `task.sync()` and direct JSON serialization

**[cmd/daemon/task.mbt](cmd/daemon/task.mbt):**
- Made `Task` struct public
- Added `queued_messages` field to `Task` struct
- Added `Task::new()` constructor
- Added `Task::sync()` method
- Modified `sync_queued_messages()` to update task's internal state
- Implemented comprehensive `FromJson` trait for `Task`
- Updated `ToJson` to include `queued_messages` field
- Added `FromJson` derive for `QueuedMessage`

**[cmd/daemon/pkg.generated.mbti](cmd/daemon/pkg.generated.mbti):**
- Exported `Task` type
- Added public trait implementations for `ToJson` and `FromJson`

## Tests

Updated the existing test `"Task::ToJson"` to include `queued_messages` field verification, ensuring the new serialization logic correctly includes all task data.