### PR TITLE
Migrate httpx README tests from 'moonbit test(async)' to 'mbt check'

### DIFF
--- a/internal/httpx/README.mbt.md
+++ b/internal/httpx/README.mbt.md
@@ -31,40 +31,43 @@ enum ExampleResponse {
 } derive(ToJson)
 ```
 
-```moonbit test(async)
+```mbt check
 ///|
-let router = @httpx.Router::new()
+async test "Minimal JSON API Server" {
+  let router = @httpx.Router::new()
 
-// Register a POST /task handler that reads and writes JSON
-router.add_handler(Post, "/task", (r, w) => {
-  let r = @httpx.JsonRequestReader::new(r)
-  let w = @httpx.JsonResponseWriter::new(w)
-  let task : ExampleRequest = r.read()
-  w.write_header(@status.Ok)
-  let res = ExampleResponse::Ok(task)
-  w.write(res)
-})
-
-// Start the HTTP server with the router
-let server = @httpx.Server::new("[::1]", 0)
-
-// Tests to verify the /task endpoint
-@async.with_task_group(group => {
-  // Start the server with CORS enabled
-  group.spawn_bg(
-    () => server.serve(@httpx.cors(router.handler())),
-    no_wait=true,
-  )
-  let (r, b) = @httpx.post_json("http://localhost:\{server.port()}/task", {
-    "name": "Example Task",
-    "description": "This is an example task.",
+  // Register a POST /task handler that reads and writes JSON
+  router.add_handler(Post, "/task", (r, w) => {
+    let r = @httpx.JsonRequestReader::new(r)
+    let w = @httpx.JsonResponseWriter::new(w)
+    let task : ExampleRequest = r.read()
+    w.write_header(@status.Ok)
+    let res = ExampleResponse::Ok(task)
+    w.write(res)
   })
-  @json.inspect(r.code, content=@status.Ok.to_json())
-  @json.inspect(b.json(), content=[
-    "Ok",
-    { "name": "Example Task", "description": "This is an example task." },
-  ])
-})
+
+  // Start the HTTP server with the router
+  let server = @httpx.Server::new("[::1]", 0)
+
+  // Tests to verify the /task endpoint
+  @async.with_task_group(group => {
+    // Start the server with CORS enabled
+    group.spawn_bg(no_wait=true, () => server.serve(
+      @httpx.cors(router.handler()),
+    ))
+    let (r, b) = @httpx.post_json("http://localhost:\{server.port()}/task", {
+      "name": "Example Task",
+      "description": "This is an example task.",
+    })
+    guard r.code is @status.Ok else {
+      fail("Unexpected response code: \{r.code}")
+    }
+    @json.inspect(b.json(), content=[
+      "Ok",
+      { "name": "Example Task", "description": "This is an example task." },
+    ])
+  })
+}
 ```
 
 ### Router and File Server
@@ -72,52 +75,73 @@ let server = @httpx.Server::new("[::1]", 0)
 You can combine the router with `FileServer` to serve static files and dynamic
 routes from the same HTTP server:
 
-```moonbit test(async)
-let file_server = @httpx.FileServer::new("cmd/server")
+```mbt check
+///|
+async test "Router and File Server" {
+  let file_server = @httpx.FileServer::new("cmd/server")
 
-// Fallback to file server when no route matches
-let router = @httpx.Router::new()
-router.add_handler(Get, "/hello", (_, w) => {
-  w.write_header(@status.Ok)
-  w.write("Hello, world! from Router Handler\n")
-})
-router.set_not_found_handler((r, w) => file_server.handle(r, w))
-let server = @httpx.Server::new("[::1]", 0)
+  // Fallback to file server when no route matches
+  let router = @httpx.Router::new()
+  router.add_handler(Get, "/hello", (_, w) => {
+    w.write_header(@status.Ok)
+    w.write("Hello, world! from Router Handler\n")
+  })
+  router.set_not_found_handler((r, w) => file_server.handle(r, w))
+  let server = @httpx.Server::new("[::1]", 0)
 
-// Start the server and test both the dynamic route and static file serving
-@async.with_task_group(group => {
-  group.spawn_bg(() => server.serve(router.handler()), no_wait=true)
-  let (r, b) = @http.get("http://localhost:\{server.port()}/hello")
-  @json.inspect(r.code, content=@status.Ok.to_json())
-  @json.inspect(b.text(), content="Hello, world! from Router Handler\n")
-  let (r, _) = @http.get("http://localhost:\{server.port()}/")
-  @json.inspect(r.code, content=@status.Ok.to_json())
-})
+  // Start the server and test both the dynamic route and static file serving
+  @async.with_task_group(group => {
+    group.spawn_bg(() => server.serve(router.handler()), no_wait=true)
+    let (r, b) = @http.get("http://localhost:\{server.port()}/hello")
+    guard r.code is @status.Ok else {
+      fail("Unexpected response code: \{r.code}")
+    }
+    guard b.text() is "Hello, world! from Router Handler\n" else {
+      fail("Unexpected response body: \{b.text()}")
+    }
+    let (r, _) = @http.get("http://localhost:\{server.port()}/")
+    guard r.code is @status.Ok else {
+      fail("Unexpected response code: \{r.code}")
+    }
+  })
+}
 ```
 
 ### Enabling CORS
 
 The `cors` middleware adds permissive CORS headers to all responses:
 
-```moonbit test(async)
-let file_server = @httpx.FileServer::new("cmd/server")
-let router = @httpx.Router::new()
-router.add_handler(Get, "/hello", (_, w) => {
-  w.write_header(@status.Ok)
-  w.write("Hello, world! from Router Handler\n")
-})
-router.set_not_found_handler((r, w) => file_server.handle(r, w))
-let server = @httpx.Server::new("[::1]", 0)
-@async.with_task_group(group => {
-  group.spawn_bg(
-    () => server.serve(@httpx.cors(router.handler())),
-    no_wait=true,
-  )
-  let (r, b) = @http.get("http://localhost:\{server.port()}/hello")
-  @json.inspect(r.code, content=@status.Ok.to_json())
-  @json.inspect(r.headers["access-control-allow-origin"], content="*")
-  @json.inspect(r.headers["access-control-allow-methods"], content="*")
-  @json.inspect(r.headers["access-control-allow-headers"], content="*")
-  @json.inspect(b.text(), content="Hello, world! from Router Handler\n")
-})
+```mbt check
+///|
+async test "CORS Middleware" {
+  let file_server = @httpx.FileServer::new("cmd/server")
+  let router = @httpx.Router::new()
+  router.add_handler(Get, "/hello", (_, w) => {
+    w.write_header(@status.Ok)
+    w.write("Hello, world! from Router Handler\n")
+  })
+  router.set_not_found_handler((r, w) => file_server.handle(r, w))
+  let server = @httpx.Server::new("[::1]", 0)
+  @async.with_task_group(group => {
+    group.spawn_bg(no_wait=true, () => server.serve(
+      @httpx.cors(router.handler()),
+    ))
+    let (r, b) = @http.get("http://localhost:\{server.port()}/hello")
+    guard r.code is @status.Ok else {
+      fail("Unexpected response code: \{r.code}")
+    }
+    guard r.headers
+      is {
+        "access-control-allow-origin": "*",
+        "access-control-allow-methods": "*",
+        "access-control-allow-headers": "*",
+        ..
+      } else {
+      fail("CORS headers missing or incorrect")
+    }
+    guard b.text() is "Hello, world! from Router Handler\n" else {
+      fail("Unexpected response body: \{b.text()}")
+    }
+  })
+}
 ```


### PR DESCRIPTION
## Summary

Converts all async test examples in `internal/httpx/README.mbt.md` from inline `moonbit test(async)` blocks to proper `mbt check` blocks with named test declarations.

## Changes

### Before
```moonbit test(async)
let router = @httpx.Router::new()
// test code...
```

### After
```mbt check
///|
async test "Test Name" {
  let router = @httpx.Router::new()
  // test code with guard statements...
}
```

## Improvements

1. **Named tests**: Each test now has a descriptive name for better reporting
2. **Better error messages**: Replaced `@json.inspect` with `guard` statements that provide explicit failure messages
3. **Consistent format**: All three examples follow the same pattern

## Tests Converted

- ✅ Minimal JSON API Server
- ✅ Router and File Server  
- ✅ CORS Middleware

All tests pass successfully:
```
moon test -p moonbitlang/maria/internal/httpx -f README.mbt.md --target native
Total tests: 3, passed: 3, failed: 0.
```