### PR TITLE
fix: remove manual O_NONBLOCK from TTY raw mode to fix WSL2/Linux startup crash

### DIFF
--- a/internal/tty/tty.c
+++ b/internal/tty/tty.c
@@ -30,11 +30,6 @@ moonbit_maria_tty_get_win_size(int32_t *size) {
 MOONBIT_FFI_EXPORT
 int32_t
 moonbit_maria_tty_set_raw_mode(int32_t fd) {
-  int32_t flags = fcntl(fd, F_GETFL);
-  flags |= O_NONBLOCK;
-  if (fcntl(fd, F_SETFL, flags) == -1) {
-    return errno;
-  }
   struct termios term;
   if (tcgetattr(fd, &term) == -1) {
     return errno;


### PR DESCRIPTION
## Summary

When running maria locally on WSL2 (Linux) using `moon run cmd/main`, the application would crash immediately after model detection with the following error:

```shell
OSError("@stdio.Input::read(): Resource temporarily unavailable")
```

This occurs because `internal/tty/tty.c` was manually setting the `O_NONBLOCK` flag on the terminal file descriptor (`stdin`) using `fcntl`. This manual state change conflicts with how the `moonbitlang/async` runtime manages non-blocking I/O. By removing this manual flag, we let the async runtime's standard I/O handlers manage the file descriptor state correctly, resolving the `EAGAIN` crash in WSL2 and other Linux environments.