### PR TITLE
fix: add `with longest` to lexmatch usages

### DIFF
--- a/internal/buildinfo/version.mbt
+++ b/internal/buildinfo/version.mbt
@@ -27,7 +27,7 @@ pub let version : Version = try! Version::parse(version_string)
 
 ///|
 pub fn Version::parse(string : String) -> Version raise {
-  lexmatch string {
+  lexmatch string with longest {
     (
       ("[[:digit:]]+" as major)
       "\."

--- a/internal/git/line_number.mbt
+++ b/internal/git/line_number.mbt
@@ -98,7 +98,7 @@ fn add_line_number_to_diff(diff_text : String) -> String raise {
         "\{state.marker} \{original_line_number} \{modified_line_number} \\\{line}",
       )
     } else {
-      lexmatch line {
+      lexmatch line with longest {
         (
           "@@[[:space:]]+-"
           ("[[:digit:]]+" as os)


### PR DESCRIPTION
## Summary
- Resolves the `lexmatch` first-match deprecation warning in two call sites
- Both call sites (`version.mbt`, `line_number.mbt`) have multiple patterns where longest-match is the intended behavior

## Test plan
- [x] `moon check` confirms 0 lexmatch warnings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)