### PR TITLE
fix: use explicit `b` prefix for byte/bytes literals

### DIFF
--- a/cmd/main/interactive/interactive.mbt
+++ b/cmd/main/interactive/interactive.mbt
@@ -88,7 +88,7 @@ pub async fn interactive(args : ArrayView[String]) -> Unit {
     ) -> Unit {
       let qms = maria.agent.clear_inputs()
       for qm in qms {
-        rl.set_prompt("$ ")
+        rl.set_prompt(b"$ ")
         rl.set_line(@encoding/utf8.encode(qm.message.content()))
         rl.prompt()
         break
@@ -107,9 +107,9 @@ pub async fn interactive(args : ArrayView[String]) -> Unit {
             } else {
               // Clear the current input line
               println("")
-              rl.set_line("")
+              rl.set_line(b"")
               // Re-prompt the user
-              rl.set_prompt("$ ")
+              rl.set_prompt(b"$ ")
               rl.prompt()
               continue
             }
@@ -139,7 +139,7 @@ pub async fn interactive(args : ArrayView[String]) -> Unit {
       }
     }
     while true {
-      rl.set_prompt("$ ")
+      rl.set_prompt(b"$ ")
       rl.prompt()
       let prompt = rl.read_line()
       let round = group.spawn(

--- a/internal/c/README.mbt.md
+++ b/internal/c/README.mbt.md
@@ -47,11 +47,11 @@ terminating `0` byte:
 ///|
 test {
   let s : Pointer[Byte] = @c.malloc(6)
-  s[0] = 'h'
-  s[1] = 'e'
-  s[2] = 'l'
-  s[3] = 'l'
-  s[4] = 'o'
+  s[0] = b'h'
+  s[1] = b'e'
+  s[2] = b'l'
+  s[3] = b'l'
+  s[4] = b'o'
   s[5] = 0
   json_inspect(strlen(s), content="5")
   @c.free(s)

--- a/internal/c/strlen_test.mbt
+++ b/internal/c/strlen_test.mbt
@@ -1,11 +1,11 @@
 ///|
 test "strlen" {
   let s : @c.Pointer[Byte] = @c.malloc(6)
-  s[0] = 'h'
-  s[1] = 'e'
-  s[2] = 'l'
-  s[3] = 'l'
-  s[4] = 'o'
+  s[0] = b'h'
+  s[1] = b'e'
+  s[2] = b'l'
+  s[3] = b'l'
+  s[4] = b'o'
   s[5] = 0
   json_inspect(@c.strlen(s), content="5")
 }

--- a/internal/pino/transport.mbt
+++ b/internal/pino/transport.mbt
@@ -103,7 +103,7 @@ async fn Transport::write(self : Transport, content : Json) -> Unit {
       let content = content.to_json().stringify()
       let buffer = @buffer.new()
       buffer.write_bytes(@encoding/utf8.encode(content))
-      buffer.write_byte('\n')
+      buffer.write_byte(b'\n')
       file.write(buffer.to_bytes())
     }
     Channel(channel) => channel.put(content)

--- a/internal/readline/csi/csi.mbt
+++ b/internal/readline/csi/csi.mbt
@@ -1,29 +1,29 @@
 ///|
 /// ASCII escape byte for ANSI control sequences.
-pub const Escape : Byte = '\x1b'
+pub const Escape : Byte = b'\x1b'
 
 ///|
 /// Clear from cursor to the beginning of the line.
-pub const ClearToLineBeginning : Bytes = "\x1b[1K"
+pub const ClearToLineBeginning : Bytes = b"\x1b[1K"
 
 ///|
 /// Clear from cursor to the end of the line.
-pub const ClearToLineEnd : Bytes = "\x1b[0K"
+pub const ClearToLineEnd : Bytes = b"\x1b[0K"
 
 ///|
 /// Clear the entire line.
-pub const ClearLine : Bytes = "\x1b[2K"
+pub const ClearLine : Bytes = b"\x1b[2K"
 
 ///|
 /// Clear the screen from cursor downward.
-pub const ClearScreenDown : Bytes = "\x1b[0J"
+pub const ClearScreenDown : Bytes = b"\x1b[0J"
 
 ///|
 /// Build a CSI escape sequence from a command payload.
 pub fn csi(command : Bytes) -> Bytes {
   let buffer = @buffer.new()
   buffer.write_byte(Escape)
-  buffer.write_byte('[')
+  buffer.write_byte(b'[')
   buffer.write_bytes(command)
   buffer.to_bytes()
 }

--- a/internal/readline/history.mbt
+++ b/internal/readline/history.mbt
@@ -34,7 +34,7 @@ fn HistoryManager::can_navigate_to_prev(self : HistoryManager) -> Bool {
 /// Remove leading spaces.
 fn BytesView::trim_start(self : BytesView) -> BytesView {
   loop self {
-    [' ', .. rest] => continue rest
+    [b' ', .. rest] => continue rest
     [.. rest] => break rest
   }
 }
@@ -43,7 +43,7 @@ fn BytesView::trim_start(self : BytesView) -> BytesView {
 /// Remove trailing spaces.
 fn BytesView::trim_end(self : BytesView) -> BytesView {
   loop self {
-    [.. rest, ' '] => continue rest
+    [.. rest, b' '] => continue rest
     [.. rest] => break rest
   }
 }
@@ -58,8 +58,8 @@ fn BytesView::trim(self : BytesView) -> BytesView {
 /// Split on `from`, reverse the parts, and rejoin with `to`.
 fn reverse_string(
   line : BytesView,
-  from? : Byte = '\r',
-  to? : Byte = '\r',
+  from? : Byte = b'\r',
+  to? : Byte = b'\r',
 ) -> BytesView {
   let parts = []
   let mut start = 0
@@ -93,7 +93,7 @@ fn HistoryManager::add_history(
   last_command_errored~ : Bool,
 ) -> BytesView {
   if line.length() == 0 {
-    return ""
+    return b""
   }
   if self.size == 0 {
     return line
@@ -106,7 +106,7 @@ fn HistoryManager::add_history(
   } else if last_command_errored {
     self.history.pop_back() |> ignore()
   }
-  let normalized_line = reverse_string(line, from='\n', to='\r')
+  let normalized_line = reverse_string(line, from=b'\n', to=b'\r')
   if self.history.length() == 0 || self.history.back() != Some(normalized_line) {
     // if self.remove_history_duplicates {
     //   for i, entry in self.history {

--- a/internal/readline/readline.mbt
+++ b/internal/readline/readline.mbt
@@ -116,11 +116,11 @@ pub fn interface(
 ) -> Interface raise {
   @tty.set_raw_mode(input.fd())
   Interface::{
-    line: "",
+    line: b"",
     input,
     output,
-    prompt: "",
-    old_prompt: "",
+    prompt: b"",
+    old_prompt: b"",
     tab_size: DefaultTabSize,
     cursor: 0,
     previous_cursor: 0,
@@ -140,7 +140,7 @@ pub fn interface(
     events: Events::new(),
     history_manager: HistoryManager::new(DefaultHistorySize),
     saw_return_at: 0,
-    previous_line: "",
+    previous_line: b"",
     last_command_errored: false,
     crlf_delay: DefaultCrlfDelay,
     is_completion_enabled: false,
@@ -161,7 +161,7 @@ pub fn Interface::set_line(self : Interface, line : BytesView) -> Unit {
   self.line = line
   loop line[:] {
     [] => break
-    ['\n', ..] => {
+    [b'\n', ..] => {
       self.is_multiline = true
       break
     }
@@ -178,25 +178,25 @@ async fn Interface::write_move_cursor(
   let buffer = @buffer.new()
   if dx < 0 {
     buffer.write_byte(@csi.Escape)
-    buffer.write_byte('[')
+    buffer.write_byte(b'[')
     buffer.write_bytes(@encoding/utf8.encode((-dx).to_string()))
-    buffer.write_byte('D')
+    buffer.write_byte(b'D')
   } else if dx > 0 {
     buffer.write_byte(@csi.Escape)
-    buffer.write_byte('[')
+    buffer.write_byte(b'[')
     buffer.write_bytes(@encoding/utf8.encode(dx.to_string()))
-    buffer.write_byte('C')
+    buffer.write_byte(b'C')
   }
   if dy < 0 {
     buffer.write_byte(@csi.Escape)
-    buffer.write_byte('[')
+    buffer.write_byte(b'[')
     buffer.write_bytes(@encoding/utf8.encode((-dy).to_string()))
-    buffer.write_byte('A')
+    buffer.write_byte(b'A')
   } else if dy > 0 {
     buffer.write_byte(@csi.Escape)
-    buffer.write_byte('[')
+    buffer.write_byte(b'[')
     buffer.write_bytes(@encoding/utf8.encode(dy.to_string()))
-    buffer.write_byte('B')
+    buffer.write_byte(b'B')
   }
   self.output.write(buffer.to_bytes())
 }
@@ -211,19 +211,19 @@ async fn @stdio.Output::cursor_to(
     None => {
       let buffer = @buffer.new()
       buffer.write_byte(@csi.Escape)
-      buffer.write_byte('[')
+      buffer.write_byte(b'[')
       buffer.write_bytes(@encoding/utf8.encode((col + 1).to_string()))
-      buffer.write_byte('G')
+      buffer.write_byte(b'G')
       self.write(buffer.to_bytes())
     }
     Some(row) => {
       let buffer = @buffer.new()
       buffer.write_byte(@csi.Escape)
-      buffer.write_byte('[')
+      buffer.write_byte(b'[')
       buffer.write_bytes(@encoding/utf8.encode((row + 1).to_string()))
-      buffer.write_byte(';')
+      buffer.write_byte(b';')
       buffer.write_bytes(@encoding/utf8.encode((col + 1).to_string()))
-      buffer.write_byte('H')
+      buffer.write_byte(b'H')
       self.write(buffer.to_bytes())
     }
   }
@@ -250,7 +250,7 @@ async fn Interface::refresh_line(self : Interface) -> Unit {
   if self.is_multiline {
     let lines = []
     loop self.line[:] {
-      ['\n', .. rest] as view => {
+      [b'\n', .. rest] as view => {
         lines.push(self.line[:view.start_offset()])
         continue rest
       }
@@ -311,12 +311,12 @@ fn display_position(
   let mut rows = 0
   loop str[:] {
     [] => break
-    ['\n', .. rest] => {
+    [b'\n', .. rest] => {
       rows += (offset + col - 1) / col
       offset = if is_multiline { MultilinePrompt.length() } else { 0 }
       continue rest
     }
-    ['\t', .. rest] => {
+    [b'\t', .. rest] => {
       offset += tab_size - offset % tab_size
       continue rest
     }
@@ -533,7 +533,7 @@ fn Interface::push_to_kill_ring(
   self : Interface,
   del : BytesView,
 ) -> Unit noraise {
-  if del == "" || self.kill_ring.back() == Some(del) {
+  if del == b"" || self.kill_ring.back() == Some(del) {
     return
   }
   self.kill_ring.push_back(del)
@@ -585,8 +585,8 @@ async fn Interface::history_next(self : Interface) -> Unit {
   self.before_edit(self.line, self.cursor)
   self.set_line(
     self.history_manager
-    .navigate_to_next(self.substring_search.unwrap_or(""))
-    .unwrap_or(""),
+    .navigate_to_next(self.substring_search.unwrap_or(b""))
+    .unwrap_or(b""),
   )
   self.cursor = self.line.length()
   self.refresh_line()
@@ -601,8 +601,8 @@ async fn Interface::history_prev(self : Interface) -> Unit {
   self.before_edit(self.line, self.cursor)
   self.set_line(
     self.history_manager
-    .navigate_to_previous(self.substring_search.unwrap_or(""))
-    .unwrap_or(""),
+    .navigate_to_previous(self.substring_search.unwrap_or(b""))
+    .unwrap_or(b""),
   )
   self.cursor = self.line.length()
   self.refresh_line()
@@ -777,7 +777,7 @@ pub fn Interface::add_new_line_on_tty(self : Interface) -> Unit {
   self.restore_previous_state()
   let before_cursor = self.line[:self.cursor]
   let after_cursor = self.line[self.cursor:]
-  self.set_line([..before_cursor, '\n', ..after_cursor])
+  self.set_line([..before_cursor, b'\n', ..after_cursor])
   self.cursor += 1
 }
 
@@ -795,7 +795,7 @@ fn Interface::add_history(self : Interface) -> BytesView {
 async fn Interface::clear_line(self : Interface) -> Unit {
   self.move_cursor(self.line.length() - self.cursor)
   self.output.write("\r\n")
-  self.set_line("")
+  self.set_line(b"")
   self.cursor = 0
   self.prev_rows = 0
 }
@@ -884,7 +884,7 @@ async fn Interface::multiline_move(
 async fn Interface::move_up_or_history_prev(self : Interface) -> Unit {
   let cursor_pos = self.get_cursor_pos()
   if self.is_multiline && cursor_pos.rows > 0 {
-    let split_lines = self.line.split('\n')
+    let split_lines = self.line.split(b'\n')
     self.multiline_move(-1, split_lines, cursor_pos)
     return
   }
@@ -896,7 +896,7 @@ async fn Interface::move_up_or_history_prev(self : Interface) -> Unit {
 /// Move cursor down in multiline, or navigate to next history entry.
 async fn Interface::move_down_or_history_next(self : Interface) -> Unit {
   let cursor_pos = self.get_cursor_pos()
-  let split_lines = self.line.split('\n')
+  let split_lines = self.line.split(b'\n')
   if self.is_multiline && cursor_pos.rows + 1 < split_lines.length() {
     self.multiline_move(1, split_lines, cursor_pos)
     return
@@ -936,7 +936,7 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
     name: Undefined,
     ctrl: false,
     shift: false,
-    sequence: "",
+    sequence: b"",
   }
   if ch is @csi.Escape {
     escaped = true
@@ -947,26 +947,26 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
       s.write_byte(ch)
     }
   }
-  if escaped && ch is ('O' | '[') {
+  if escaped && ch is (b'O' | b'[') {
     // ANSI escape sequence
     let code = @buffer.new()
     let mut modifier = 0
-    if ch is 'O' {
+    if ch is b'O' {
       // ESC O letter
       // ESC O modifier letter
       ch = self.read_byte()
       s.write_byte(ch)
-      if ch is ('0'..='9') {
+      if ch is (b'0'..=b'9') {
         modifier = ch.to_int() - '0' - 1
         ch = self.read_byte()
         s.write_byte(ch)
       }
       code.write_byte(ch)
-    } else if ch is '[' {
+    } else if ch is b'[' {
       // ESC [ sequences
       ch = self.read_byte()
       s.write_byte(ch)
-      if ch is '[' {
+      if ch is b'[' {
         // Double bracket sequences like \x1b[[A
         code.write_byte(ch)
         ch = self.read_byte()
@@ -975,15 +975,15 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
       let cmd = @buffer.new()
 
       // Skip one or two leading digits
-      if ch is ('0'..='9') {
+      if ch is (b'0'..=b'9') {
         ch = self.read_byte()
         s.write_byte(ch)
         cmd.write_byte(ch)
-        if ch is ('0'..='9') {
+        if ch is (b'0'..=b'9') {
           ch = self.read_byte()
           s.write_byte(ch)
           cmd.write_byte(ch)
-          if ch is ('0'..='9') {
+          if ch is (b'0'..=b'9') {
             ch = self.read_byte()
             s.write_byte(ch)
             cmd.write_byte(ch)
@@ -992,11 +992,11 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
       }
 
       // skip modifier
-      if ch is ';' {
+      if ch is b';' {
         ch = self.read_byte()
         s.write_byte(ch)
         cmd.write_byte(ch)
-        if ch is ('0'..='9') {
+        if ch is (b'0'..=b'9') {
           let ch = self.read_byte()
           s.write_byte(ch)
           cmd.write_byte(ch)
@@ -1006,44 +1006,45 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
       match cmd {
         // (\d\d?)(;(\d))?([~^$])
         [
-          '0'..='9' as d0,
-          '0'..='9' as d1,
-          ';',
-          '0'..='9' as m0,
-          '~'
-          | '^'
-          | '$' as s0,
+          b'0'..=b'9' as d0,
+          b'0'..=b'9' as d1,
+          b';',
+          b'0'..=b'9' as m0,
+          b'~'
+          | b'^'
+          | b'$' as s0,
         ] => {
           code.write_byte(d0)
           code.write_byte(d1)
           code.write_byte(s0)
           modifier = m0.to_int() - '0' - 1
         }
-        ['0'..='9' as d0, '0'..='9' as d1, '~' | '^' | '$' as s0] => {
+        [b'0'..=b'9' as d0, b'0'..=b'9' as d1, b'~' | b'^' | b'$' as s0] => {
           code.write_byte(d0)
           code.write_byte(d1)
           code.write_byte(s0)
           modifier = 0
         }
-        ['0'..='9' as d0, ';', '0'..='9' as m0, '~' | '^' | '$' as s0] => {
+        [b'0'..=b'9' as d0, b';', b'0'..=b'9' as m0, b'~' | b'^' | b'$' as s0] => {
           code.write_byte(d0)
           code.write_byte(s0)
           modifier = m0.to_int() - '0' - 1
         }
-        ['0'..='9' as d0, '~' | '^' | '$' as s0] => {
+        [b'0'..=b'9' as d0, b'~' | b'^' | b'$' as s0] => {
           code.write_byte(d0)
           code.write_byte(s0)
           modifier = 0
         }
         // (\d{3}~)
-        ['0'..='9', '0'..='9', '0'..='9', '~'] => code.write_bytesview(cmd)
+        [b'0'..=b'9', b'0'..=b'9', b'0'..=b'9', b'~'] =>
+          code.write_bytesview(cmd)
         // ((\d;)?(\d))?([A-Za-z])
-        ['0'..='9', ';', '0'..='9' as m0, 'a'..='z' | 'A'..='z' as c0]
-        | ['0'..='9' as m0, 'a'..='z' | 'A'..='z' as c0] => {
+        [b'0'..=b'9', b';', b'0'..=b'9' as m0, b'a'..=b'z' | b'A'..=b'z' as c0]
+        | [b'0'..=b'9' as m0, b'a'..=b'z' | b'A'..=b'z' as c0] => {
           code.write_byte(c0)
           modifier = m0.to_int() - '0' - 1
         }
-        ['a'..='z' | 'A'..='z' as c0] => {
+        [b'a'..=b'z' | b'A'..=b'z' as c0] => {
           code.write_byte(c0)
           modifier = 0
         }
@@ -1058,166 +1059,166 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
     let code = code.to_bytes()
     match code {
       // xterm/gnome ESC [ letter (with modifier)
-      "[P" => key.name = F1
-      "[Q" => key.name = F2
-      "[R" => key.name = F3
-      "[S" => key.name = F4
+      b"[P" => key.name = F1
+      b"[Q" => key.name = F2
+      b"[R" => key.name = F3
+      b"[S" => key.name = F4
 
       // xterm/gnome ESC O letter (without modifier)
-      "OP" => key.name = F1
-      "OQ" => key.name = F2
-      "OR" => key.name = F3
-      "OS" => key.name = F4
+      b"OP" => key.name = F1
+      b"OQ" => key.name = F2
+      b"OR" => key.name = F3
+      b"OS" => key.name = F4
 
       // xterm/rxvt ESC [ number ~
-      "[11~" => key.name = F1
-      "[12~" => key.name = F2
-      "[13~" => key.name = F3
-      "[14~" => key.name = F4
-      "[15~" => key.name = F5
-      "[17~" => key.name = F6
-      "[18~" => key.name = F7
-      "[19~" => key.name = F8
-      "[20~" => key.name = F9
-      "[21~" => key.name = F10
-      "[23~" => key.name = F11
-      "[24~" => key.name = F12
+      b"[11~" => key.name = F1
+      b"[12~" => key.name = F2
+      b"[13~" => key.name = F3
+      b"[14~" => key.name = F4
+      b"[15~" => key.name = F5
+      b"[17~" => key.name = F6
+      b"[18~" => key.name = F7
+      b"[19~" => key.name = F8
+      b"[20~" => key.name = F9
+      b"[21~" => key.name = F10
+      b"[23~" => key.name = F11
+      b"[24~" => key.name = F12
 
       // paste bracket mode
-      "[200~" => key.name = PasteStart
-      "[201~" => key.name = PasteEnd
+      b"[200~" => key.name = PasteStart
+      b"[201~" => key.name = PasteEnd
 
       // from Cygwin and used in libuv
-      "[[A" => key.name = F1
-      "[[B" => key.name = F2
-      "[[C" => key.name = F3
-      "[[D" => key.name = F4
-      "[[E" => key.name = F5
+      b"[[A" => key.name = F1
+      b"[[B" => key.name = F2
+      b"[[C" => key.name = F3
+      b"[[D" => key.name = F4
+      b"[[E" => key.name = F5
 
       // xterm ESC [ letter
-      "[A" => key.name = Up
-      "[B" => key.name = Down
-      "[C" => key.name = Right
-      "[D" => key.name = Left
-      "[E" => key.name = Clear
-      "[F" => key.name = End
-      "[H" => key.name = Home
+      b"[A" => key.name = Up
+      b"[B" => key.name = Down
+      b"[C" => key.name = Right
+      b"[D" => key.name = Left
+      b"[E" => key.name = Clear
+      b"[F" => key.name = End
+      b"[H" => key.name = Home
 
       // xterm/gnome ESC O letter
-      "OA" => key.name = Up
-      "OB" => key.name = Down
-      "OC" => key.name = Right
-      "OD" => key.name = Left
-      "OE" => key.name = Clear
-      "OF" => key.name = End
-      "OH" => key.name = Home
+      b"OA" => key.name = Up
+      b"OB" => key.name = Down
+      b"OC" => key.name = Right
+      b"OD" => key.name = Left
+      b"OE" => key.name = Clear
+      b"OF" => key.name = End
+      b"OH" => key.name = Home
 
       // xterm/rxvt ESC [ number ~
-      "[1~" => key.name = Home
-      "[2~" => key.name = Insert
-      "[3~" => key.name = Delete
-      "[4~" => key.name = End
-      "[5~" => key.name = PageUp
-      "[6~" => key.name = PageDown
-      "[7~" => key.name = Home
-      "[8~" => key.name = End
+      b"[1~" => key.name = Home
+      b"[2~" => key.name = Insert
+      b"[3~" => key.name = Delete
+      b"[4~" => key.name = End
+      b"[5~" => key.name = PageUp
+      b"[6~" => key.name = PageDown
+      b"[7~" => key.name = Home
+      b"[8~" => key.name = End
 
       // putty
-      "[[5~" => key.name = PageUp
-      "[[6~" => key.name = PageDown
+      b"[[5~" => key.name = PageUp
+      b"[[6~" => key.name = PageDown
 
       // rxvt keys with modifiers
-      "[a" => {
+      b"[a" => {
         key.shift = true
         key.name = Up
       }
-      "[b" => {
+      b"[b" => {
         key.shift = true
         key.name = Down
       }
-      "[c" => {
+      b"[c" => {
         key.shift = true
         key.name = Right
       }
-      "[d" => {
+      b"[d" => {
         key.shift = true
         key.name = Left
       }
-      "[e" => {
+      b"[e" => {
         key.shift = true
         key.name = Clear
       }
-      "[2$" => {
+      b"[2$" => {
         key.shift = true
         key.name = Insert
       }
-      "[3$" => {
+      b"[3$" => {
         key.shift = true
         key.name = Delete
       }
-      "[5$" => {
+      b"[5$" => {
         key.shift = true
         key.name = PageUp
       }
-      "[6$" => {
+      b"[6$" => {
         key.shift = true
         key.name = PageDown
       }
-      "[7$" => {
+      b"[7$" => {
         key.shift = true
         key.name = Home
       }
-      "[8$" => {
+      b"[8$" => {
         key.shift = true
         key.name = End
       }
-      "Oa" => {
+      b"Oa" => {
         key.ctrl = true
         key.name = Up
       }
-      "Ob" => {
+      b"Ob" => {
         key.ctrl = true
         key.name = Down
       }
-      "Oc" => {
+      b"Oc" => {
         key.ctrl = true
         key.name = Right
       }
-      "Od" => {
+      b"Od" => {
         key.ctrl = true
         key.name = Left
       }
-      "Oe" => {
+      b"Oe" => {
         key.ctrl = true
         key.name = Clear
       }
-      "[2^" => {
+      b"[2^" => {
         key.ctrl = true
         key.name = Insert
       }
-      "[3^" => {
+      b"[3^" => {
         key.ctrl = true
         key.name = Delete
       }
-      "[5^" => {
+      b"[5^" => {
         key.ctrl = true
         key.name = PageUp
       }
-      "[6^" => {
+      b"[6^" => {
         key.ctrl = true
         key.name = PageDown
       }
-      "[7^" => {
+      b"[7^" => {
         key.ctrl = true
         key.name = Home
       }
-      "[8^" => {
+      b"[8^" => {
         key.ctrl = true
         key.name = End
       }
 
       // misc
-      "[Z" => {
+      b"[Z" => {
         key.shift = true
         key.name = Tab
       }
@@ -1225,24 +1226,24 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
     }
   } else {
     match ch {
-      '\r' => {
+      b'\r' => {
         key.name = Return
         key.meta = escaped
       }
-      '\n' => {
+      b'\n' => {
         key.name = Enter
         key.meta = escaped
       }
-      '\t' => {
+      b'\t' => {
         key.name = Tab
         key.meta = escaped
       }
-      '\b' | 0x7f => key.name = Backspace
+      b'\b' | 0x7f => key.name = Backspace
       @csi.Escape => {
         key.name = Escape
         key.meta = escaped
       }
-      ' ' => {
+      b' ' => {
         key.name = Space
         key.meta = escaped
       }
@@ -1250,12 +1251,12 @@ async fn Interface::emit_keypress(self : Interface) -> Unit {
         key.name = Byte((ch.to_int() + b'a'.to_int() - 1).to_byte())
         key.ctrl = true
       }
-      'A'..='Z' => {
+      b'A'..=b'Z' => {
         key.name = Byte((ch.to_int() + b'a'.to_int() - b'A'.to_int()).to_byte())
         key.shift = true
         key.meta = escaped
       }
-      '0'..='9' | 'a'..='z' => {
+      b'0'..=b'9' | b'a'..=b'z' => {
         key.name = Byte(ch)
         key.shift = false
         key.meta = escaped
@@ -1368,27 +1369,27 @@ async fn Interface::tab_completer(
   width = width + 2
   let max_columns = @cmp.maximum(1, self.columns() / width)
   let output = @buffer.new()
-  output.write_bytes("\r\n")
+  output.write_bytes(b"\r\n")
   let mut line_index = 0
   let mut whitespace = 0
   for i, completion in completions {
     if completion is "" || line_index == max_columns {
-      output.write_bytes("\r\n")
+      output.write_bytes(b"\r\n")
       line_index = 0
       whitespace = 0
     } else {
-      output.write_bytesview(Bytes::make(whitespace, ' '))
+      output.write_bytesview(Bytes::make(whitespace, b' '))
     }
     if completion.length() > 0 {
       output.write_bytes(@encoding/utf8.encode(completion))
       whitespace = width - completion_widths[i]
       line_index += 1
     } else {
-      output.write_bytes("\r\n")
+      output.write_bytes(b"\r\n")
     }
   }
   if line_index != 0 {
-    output.write_bytes("\r\n\r\n")
+    output.write_bytes(b"\r\n\r\n")
   }
   self.output.write(output.to_bytes())
   self.refresh_line()
@@ -1405,7 +1406,7 @@ async fn Interface::handle_keypress(
   let previous_key = self.previous_key
   self.previous_key = Some(key)
   let mut should_reset_previous_cursor_cols = true
-  if !key.meta || !(key.name is Byte('y')) {
+  if !key.meta || !(key.name is Byte(b'y')) {
     self.yanking = false
   }
   if key.name is (Up | Down) && !key.ctrl && !key.meta && !key.shift {
@@ -1434,32 +1435,32 @@ async fn Interface::handle_keypress(
     }
   } else if key.ctrl {
     match key.name {
-      Byte('c') => raise Aborted::CtrlC
-      Byte('h') => self.delete_left()
-      Byte('d') =>
+      Byte(b'c') => raise Aborted::CtrlC
+      Byte(b'h') => self.delete_left()
+      Byte(b'd') =>
         if self.cursor == 0 && self.line.length() == 0 {
           raise EOF
         } else if self.cursor < self.line.length() {
           self.delete_right()
         }
-      Byte('u') => self.delete_line_left()
-      Byte('k') => self.delete_line_right()
-      Byte('a') => self.move_cursor(-self.cursor)
-      Byte('e') => self.move_cursor(self.line.length() - self.cursor)
-      Byte('b') =>
+      Byte(b'u') => self.delete_line_left()
+      Byte(b'k') => self.delete_line_right()
+      Byte(b'a') => self.move_cursor(-self.cursor)
+      Byte(b'e') => self.move_cursor(self.line.length() - self.cursor)
+      Byte(b'b') =>
         self.move_cursor(-@unicode.char_size_left(self.line, self.cursor))
-      Byte('f') =>
+      Byte(b'f') =>
         self.move_cursor(@unicode.char_size_right(self.line, self.cursor))
-      Byte('l') => {
+      Byte(b'l') => {
         self.output.cursor_to(col=0, row=0)
         self.output.clear_screen_down()
         self.refresh_line()
       }
-      Byte('n') => self.history_next()
-      Byte('p') => self.history_prev()
-      Byte('y') => self.yank()
-      Byte('z') => @spawn.kill(@spawn.getppid(), @signal.sigtstp)
-      Byte('w') | Backspace => self.delete_word_left()
+      Byte(b'n') => self.history_next()
+      Byte(b'p') => self.history_prev()
+      Byte(b'y') => self.yank()
+      Byte(b'z') => @spawn.kill(@spawn.getppid(), @signal.sigtstp)
+      Byte(b'w') | Backspace => self.delete_word_left()
       Delete => self.delete_word_right()
       Left => self.word_left()
       Right => self.word_right()
@@ -1467,11 +1468,11 @@ async fn Interface::handle_keypress(
     }
   } else if key.meta {
     match key.name {
-      Byte('b') => self.word_left()
-      Byte('f') => self.word_right()
-      Byte('d') | Delete => self.delete_word_right()
+      Byte(b'b') => self.word_left()
+      Byte(b'f') => self.word_right()
+      Byte(b'd') | Delete => self.delete_word_right()
       Backspace => self.delete_word_left()
-      Byte('y') => self.yank_pop()
+      Byte(b'y') => self.yank_pop()
       _ => ()
     }
   } else {

--- a/internal/readline/readline_wbtest.mbt
+++ b/internal/readline/readline_wbtest.mbt
@@ -48,7 +48,7 @@ test "display_position_zero_col_returns_zero" {
 
 ///|
 test "display_position_empty_string" {
-  let bytes : Bytes = ""
+  let bytes : Bytes = b""
   let pos = display_position(bytes, col=80, is_multiline=false, tab_size=4)
   assert_eq(pos.cols, 0)
   assert_eq(pos.rows, 0)
@@ -100,12 +100,12 @@ test "display_position_4byte_utf8_emoji" {
 test "history_manager_add_and_navigate" {
   let hm = HistoryManager::new(10)
   let _ = hm.add_history(
-    "first",
+    b"first",
     is_multiline=false,
     last_command_errored=false,
   )
   let _ = hm.add_history(
-    "second",
+    b"second",
     is_multiline=false,
     last_command_errored=false,
   )
@@ -117,24 +117,24 @@ test "history_manager_add_and_navigate" {
 test "history_manager_navigate_previous_and_next" {
   let hm = HistoryManager::new(10)
   let _ = hm.add_history(
-    "first",
+    b"first",
     is_multiline=false,
     last_command_errored=false,
   )
   let _ = hm.add_history(
-    "second",
+    b"second",
     is_multiline=false,
     last_command_errored=false,
   )
   // With empty prefix, all entries match has_prefix("") and are skipped.
   // First call: skips all entries, returns the search string itself.
-  let r1 = hm.navigate_to_previous("")
+  let r1 = hm.navigate_to_previous(b"")
   assert_true(r1 == Some(b""))
   // Second call: can_navigate_to_prev is false (index == length), returns None.
-  let r2 = hm.navigate_to_previous("")
+  let r2 = hm.navigate_to_previous(b"")
   assert_true(r2 is None)
   // Navigate forward: returns the search string.
-  let r3 = hm.navigate_to_next("")
+  let r3 = hm.navigate_to_next(b"")
   assert_true(r3 == Some(b""))
 }
 
@@ -142,11 +142,11 @@ test "history_manager_navigate_previous_and_next" {
 test "history_manager_navigate_next_at_start" {
   let hm = HistoryManager::new(10)
   let _ = hm.add_history(
-    "first",
+    b"first",
     is_multiline=false,
     last_command_errored=false,
   )
-  let result = hm.navigate_to_next("")
+  let result = hm.navigate_to_next(b"")
   assert_true(result is None)
 }
 
@@ -154,18 +154,18 @@ test "history_manager_navigate_next_at_start" {
 test "history_manager_empty_line_not_added" {
   let hm = HistoryManager::new(10)
   let result = hm.add_history(
-    "",
+    b"",
     is_multiline=false,
     last_command_errored=false,
   )
-  assert_true(result == "")
+  assert_true(result == b"")
   assert_false(hm.can_navigate_to_prev())
 }
 
 ///|
 test "history_manager_whitespace_only_not_added" {
   let hm = HistoryManager::new(10)
-  let _ = hm.add_history("   ", is_multiline=false, last_command_errored=false)
+  let _ = hm.add_history(b"   ", is_multiline=false, last_command_errored=false)
   assert_false(hm.can_navigate_to_prev())
 }
 
@@ -173,17 +173,17 @@ test "history_manager_whitespace_only_not_added" {
 test "history_manager_size_limit" {
   let hm = HistoryManager::new(2)
   let _ = hm.add_history(
-    "first",
+    b"first",
     is_multiline=false,
     last_command_errored=false,
   )
   let _ = hm.add_history(
-    "second",
+    b"second",
     is_multiline=false,
     last_command_errored=false,
   )
   let _ = hm.add_history(
-    "third",
+    b"third",
     is_multiline=false,
     last_command_errored=false,
   )
@@ -193,8 +193,16 @@ test "history_manager_size_limit" {
 ///|
 test "history_manager_duplicate_not_added" {
   let hm = HistoryManager::new(10)
-  let _ = hm.add_history("same", is_multiline=false, last_command_errored=false)
-  let _ = hm.add_history("same", is_multiline=false, last_command_errored=false)
+  let _ = hm.add_history(
+    b"same",
+    is_multiline=false,
+    last_command_errored=false,
+  )
+  let _ = hm.add_history(
+    b"same",
+    is_multiline=false,
+    last_command_errored=false,
+  )
   assert_eq(hm.history.length(), 1)
 }
 
@@ -202,17 +210,17 @@ test "history_manager_duplicate_not_added" {
 test "history_manager_zero_size" {
   let hm = HistoryManager::new(0)
   let result = hm.add_history(
-    "test",
+    b"test",
     is_multiline=false,
     last_command_errored=false,
   )
-  assert_true(result == "test")
+  assert_true(result == b"test")
   assert_false(hm.can_navigate_to_prev())
 }
 
 ///|
 test "word_size_left_at_start" {
-  let result = word_size_left("hello world", 0)
+  let result = word_size_left(b"hello world", 0)
   assert_eq(result, 0)
 }
 
@@ -220,21 +228,21 @@ test "word_size_left_at_start" {
 test "word_size_left_after_word" {
   // word_size_left returns the unmatched-suffix length of the reversed prefix.
   // "hello" reversed = "olleh", fully matched → rest.length() = 0
-  let s : BytesView = "hello world"
+  let s : BytesView = b"hello world"
   let result = word_size_left(s, 5)
   assert_eq(result, 0)
 }
 
 ///|
 test "word_size_left_at_end" {
-  let s : BytesView = "hello"
+  let s : BytesView = b"hello"
   let result = word_size_left(s, 5)
   assert_eq(result, 0)
 }
 
 ///|
 test "word_right_left_at_end" {
-  let s : BytesView = "hello"
+  let s : BytesView = b"hello"
   let result = word_right_left(s, 5)
   assert_eq(result, 0)
 }
@@ -242,7 +250,7 @@ test "word_right_left_at_end" {
 ///|
 test "word_right_left_at_start" {
   // "hello world" → matches "hello " (word + trailing space), rest = "world" (len 5)
-  let s : BytesView = "hello world"
+  let s : BytesView = b"hello world"
   let result = word_right_left(s, 0)
   assert_eq(result, 5)
 }
@@ -279,93 +287,93 @@ test "common_prefix_identical" {
 
 ///|
 test "bytesview_split_basic" {
-  let input : BytesView = "a\nb\nc"
-  let parts = input.split('\n')
+  let input : BytesView = b"a\nb\nc"
+  let parts = input.split(b'\n')
   assert_eq(parts.length(), 3)
-  assert_true(parts[0] == "a")
-  assert_true(parts[1] == "b")
-  assert_true(parts[2] == "c")
+  assert_true(parts[0] == b"a")
+  assert_true(parts[1] == b"b")
+  assert_true(parts[2] == b"c")
 }
 
 ///|
 test "bytesview_split_no_separator" {
-  let input : BytesView = "hello"
-  let parts = input.split('\n')
+  let input : BytesView = b"hello"
+  let parts = input.split(b'\n')
   assert_eq(parts.length(), 1)
-  assert_true(parts[0] == "hello")
+  assert_true(parts[0] == b"hello")
 }
 
 ///|
 test "bytesview_split_empty" {
-  let input : BytesView = ""
-  let parts = input.split('\n')
+  let input : BytesView = b""
+  let parts = input.split(b'\n')
   assert_eq(parts.length(), 1)
 }
 
 ///|
 test "bytesview_split_trailing_separator" {
-  let input : BytesView = "a\nb\n"
-  let parts = input.split('\n')
+  let input : BytesView = b"a\nb\n"
+  let parts = input.split(b'\n')
   assert_eq(parts.length(), 3)
-  assert_true(parts[0] == "a")
-  assert_true(parts[1] == "b")
+  assert_true(parts[0] == b"a")
+  assert_true(parts[1] == b"b")
   assert_eq(parts[2].length(), 0)
 }
 
 ///|
 test "bytesview_trim_start" {
-  let input : BytesView = "  hello"
+  let input : BytesView = b"  hello"
   let result = input.trim_start()
-  assert_true(result == "hello")
+  assert_true(result == b"hello")
 }
 
 ///|
 test "bytesview_trim_end" {
-  let input : BytesView = "hello  "
+  let input : BytesView = b"hello  "
   let result = input.trim_end()
-  assert_true(result == "hello")
+  assert_true(result == b"hello")
 }
 
 ///|
 test "bytesview_trim_both" {
-  let input : BytesView = "  hello  "
+  let input : BytesView = b"  hello  "
   let result = input.trim()
-  assert_true(result == "hello")
+  assert_true(result == b"hello")
 }
 
 ///|
 test "bytesview_trim_empty" {
-  let input : BytesView = ""
+  let input : BytesView = b""
   let result = input.trim()
-  assert_true(result == "")
+  assert_true(result == b"")
 }
 
 ///|
 test "bytesview_trim_all_spaces" {
-  let input : BytesView = "   "
+  let input : BytesView = b"   "
   let result = input.trim()
-  assert_true(result == "")
+  assert_true(result == b"")
 }
 
 ///|
 test "reverse_string_three_parts" {
-  let input : BytesView = "line1\nline2\nline3"
-  let result = reverse_string(input, from='\n', to='\r')
-  assert_true(result == "line3\rline2\rline1")
+  let input : BytesView = b"line1\nline2\nline3"
+  let result = reverse_string(input, from=b'\n', to=b'\r')
+  assert_true(result == b"line3\rline2\rline1")
 }
 
 ///|
 test "reverse_string_no_separator" {
-  let input : BytesView = "hello"
-  let result = reverse_string(input, from='\n', to='\r')
-  assert_true(result == "hello")
+  let input : BytesView = b"hello"
+  let result = reverse_string(input, from=b'\n', to=b'\r')
+  assert_true(result == b"hello")
 }
 
 ///|
 test "reverse_string_single_separator" {
-  let input : BytesView = "a\nb"
-  let result = reverse_string(input, from='\n', to='\r')
-  assert_true(result == "b\ra")
+  let input : BytesView = b"a\nb"
+  let result = reverse_string(input, from=b'\n', to=b'\r')
+  assert_true(result == b"b\ra")
 }
 
 ///|

--- a/internal/readline/unicode/width_test.mbt
+++ b/internal/readline/unicode/width_test.mbt
@@ -1,6 +1,6 @@
 ///|
 test "char_width_left" {
-  let string : Bytes = "aあ𠮷👋🌍🙂‍↕️"
+  let string : Bytes = b"aあ𠮷👋🌍🙂‍↕️"
   json_inspect(@unicode.char_width_left(string, 0), content=0)
   json_inspect(@unicode.char_width_left(string, 4), content=2)
   json_inspect(@unicode.char_width_left(string, 8), content=2)
@@ -11,7 +11,7 @@ test "char_width_left" {
 
 ///|
 test "char_width_right" {
-  let string : Bytes = "aあ𠮷👋🌍🙂‍↕️"
+  let string : Bytes = b"aあ𠮷👋🌍🙂‍↕️"
   json_inspect(@unicode.char_width_right(string, 0), content=1)
   json_inspect(@unicode.char_width_right(string, 1), content=2)
   json_inspect(@unicode.char_width_right(string, 4), content=2)


### PR DESCRIPTION
## Summary
- Adds `b` prefix to all char/string literals where the compiler was flagging deprecated implicit Byte/Bytes overloading
- ~304 sites across the codebase

## Test plan
- [x] `moon check` confirms 0 warnings of these two kinds remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)