### PR TITLE
fix: use `to_owned` for StringView/BytesView allocation

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -377,7 +377,7 @@ pub async fn new(
   history? : @conversation.Conversation,
 ) -> Agent {
   let home = match home {
-    Some(home) => home.to_string()
+    Some(home) => home.to_owned()
     None => @os.home()
   }
   // FIXME:(upstream) function with error not allowed in optional expression
@@ -386,7 +386,7 @@ pub async fn new(
     None => @uuid.generator(@rand.chacha8())
   }
   let session_manager = @conversation.Manager::new(uuid~, home~)
-  let rules = @rules.Loader::new(cwd.to_string(), logger~)
+  let rules = @rules.Loader::new(cwd.to_owned(), logger~)
   let event_target : @broadcast.Broadcast[@event.Event] = @broadcast.Broadcast::new()
   event_target.add_listener(event => {
     logger.info("Received event", data={ "event": event.to_json() })
@@ -404,7 +404,7 @@ pub async fn new(
     None =>
       session_manager.new_conversation(
         name=name.unwrap_or("New Conversation"),
-        cwd=cwd.to_string(),
+        cwd=cwd.to_owned(),
         web_search~,
       )
   }
@@ -412,12 +412,12 @@ pub async fn new(
     Some(queue) => queue
     None => @event.ExternalEventQueue::new()
   }
-  let skills = @skills.Loader::new(cwd=cwd.to_string(), logger~)
+  let skills = @skills.Loader::new(cwd=cwd.to_owned(), logger~)
   let agent = Agent::{
     logger,
     uuid,
     history,
-    cwd: cwd.to_string(),
+    cwd: cwd.to_owned(),
     model,
     tools: {},
     input_queue: [],

--- a/cmd/daemon/daemon.mbt
+++ b/cmd/daemon/daemon.mbt
@@ -59,7 +59,7 @@ pub async fn Daemon::new(
 ) -> Daemon? {
   let home = match home {
     None => @os.home()
-    Some(home) => home.to_string()
+    Some(home) => home.to_owned()
   }
   // Validate exec_path points to an existing file.
   if !@fsx.exists(exec_path) {
@@ -100,7 +100,7 @@ pub async fn Daemon::new(
     None => @uuid.generator(@rand.chacha8())
   }
   let cwd = match cwd {
-    Some(cwd) => cwd.to_string()
+    Some(cwd) => cwd.to_owned()
     None => @os.cwd()
   }
   let daemon = Daemon::{

--- a/cmd/daemon/daemon_forward_to_task.mbt
+++ b/cmd/daemon/daemon_forward_to_task.mbt
@@ -60,7 +60,7 @@ async fn Daemon::forward_to_task(
           "error": {
             "code": -1,
             "message": "Cannot resume conversation: working directory has been removed",
-            "metadata": { "cwd": cwd, "task_id": id.to_string() },
+            "metadata": { "cwd": cwd, "task_id": id.to_owned() },
           },
         })
       }

--- a/cmd/daemon/lock_daemon_file.mbt
+++ b/cmd/daemon/lock_daemon_file.mbt
@@ -30,7 +30,7 @@
 /// FIXME: Make this private. This function is currently marked as public
 /// because it is used by `cmd/test-to-be-killed` for testing.
 pub async fn lock_daemon_file(home~ : StringView) -> @fs.File? {
-  let path = Path::join(home.to_string(), ".moonagent")
+  let path = Path::join(home.to_owned(), ".moonagent")
     .join("daemon.json")
     .to_string()
   let dir = Path::dirname(path).to_string()

--- a/cmd/daemon/main.mbt
+++ b/cmd/daemon/main.mbt
@@ -72,7 +72,7 @@ pub async fn detach(
   }
   if serve is Some(serve) {
     args.push("--serve")
-    args.push(serve.to_string())
+    args.push(serve.to_owned())
   }
   if exec_path is Some(exec_path) {
     args.push(exec_path)

--- a/cmd/jsonl2md/formatter.mbt
+++ b/cmd/jsonl2md/formatter.mbt
@@ -520,7 +520,7 @@ async fn Formatter::format_log_entry(self : Formatter, json : Json) -> Unit {
     (event : @event.Event) =>
       match event.desc {
         AssistantMessage(content, tool_calls~, ..) => {
-          let content = content.trim(char_set=" \n\r\t").to_string()
+          let content = content.trim(char_set=" \n\r\t").to_owned()
           let title = content
             .split("\n")
             .drop_while(line => line.is_blank())

--- a/cmd/server/server_test.mbt
+++ b/cmd/server/server_test.mbt
@@ -49,7 +49,7 @@ async fn configure_server(
 ) -> @server.Server {
   let cwd = @os.cwd()
   let serve = match serve {
-    Some(serve) => serve.to_string()
+    Some(serve) => serve.to_owned()
     None => Path::join(cwd, "cmd/server").to_string()
   }
   configure_models(mock)

--- a/internal/buildinfo/version.mbt
+++ b/internal/buildinfo/version.mbt
@@ -59,7 +59,7 @@ pub fn Version::parse(string : String) -> Version raise {
         major,
         minor,
         patch,
-        build: Some({ number: build_number, commit: commit.to_string() }),
+        build: Some({ number: build_number, commit: commit.to_owned() }),
       }
     }
     _ => fail("Invalid version string format: " + string)

--- a/internal/conversation/manager.mbt
+++ b/internal/conversation/manager.mbt
@@ -21,7 +21,7 @@ pub async fn Manager::new(
   ),
 ) -> Manager {
   let cache = @lru.cache(max_size=100)
-  let conversations = Path::join(home.to_string(), ".moonagent")
+  let conversations = Path::join(home.to_owned(), ".moonagent")
     .join("conversations")
     .to_string()
   if !@fsx.exists(conversations) {
@@ -35,7 +35,7 @@ pub async fn Manager::load(self : Manager, id : @uuid.Uuid) -> Conversation? {
   if self.cache.get(id) is Some(id) {
     return Some(id)
   }
-  let path = Path::join(self.home.to_string(), ".moonagent")
+  let path = Path::join(self.home.to_owned(), ".moonagent")
     .join("conversations")
     .join("\{id}.json")
     .to_string()
@@ -60,7 +60,7 @@ pub async fn Manager::load(self : Manager, id : @uuid.Uuid) -> Conversation? {
 
 ///|
 pub async fn Manager::save(self : Manager, conversation : Conversation) -> Unit {
-  let path = Path::join(self.home.to_string(), ".moonagent")
+  let path = Path::join(self.home.to_owned(), ".moonagent")
     .join("conversations")
     .join("\{conversation.id}.json")
     .to_string()
@@ -72,7 +72,7 @@ pub async fn Manager::save(self : Manager, conversation : Conversation) -> Unit 
 
 ///|
 pub async fn Manager::list(self : Manager) -> Array[@uuid.Uuid] {
-  let path = Path::join(self.home.to_string(), ".moonagent")
+  let path = Path::join(self.home.to_owned(), ".moonagent")
     .join("conversations")
     .to_string()
   let entries = @fsx.list_directory(path)

--- a/internal/fsx/exists.mbt
+++ b/internal/fsx/exists.mbt
@@ -4,5 +4,5 @@
 /// The function returns `true` if the path points to any existing entry,
 /// including files, directories or symbolic links.
 pub async fn exists(path : StringView) -> Bool {
-  @fs.exists(path.to_string())
+  @fs.exists(path.to_owned())
 }

--- a/internal/fsx/file.mbt
+++ b/internal/fsx/file.mbt
@@ -8,7 +8,7 @@ struct FileRead(@fs.File)
 /// The file is created with permission `0o644` and truncated if it
 /// already exists.
 pub async fn FileRead::create(path : StringView) -> FileRead {
-  @fs.create(path.to_string(), permission=0o644)
+  @fs.create(path.to_owned(), permission=0o644)
 }
 
 ///|

--- a/internal/fsx/list_directory.mbt
+++ b/internal/fsx/list_directory.mbt
@@ -52,11 +52,11 @@ pub struct DirectoryEntry {
 /// The returned entries are sorted by their derived ordering and include
 /// the full path, basename and file kind for each item.
 pub async fn list_directory(path : StringView) -> Array[DirectoryEntry] {
-  let dir : @fs.Directory = @fs.opendir(path.to_string())
+  let dir : @fs.Directory = @fs.opendir(path.to_owned())
   defer dir.close()
   let entries = []
   for basename in dir.read_all() {
-    let filename = Path::join(path.to_string(), basename).to_string()
+    let filename = Path::join(path.to_owned(), basename).to_string()
     let kind = @fs.kind(filename, follow_symlink=false)
     entries.push(DirectoryEntry::{
       path: filename,

--- a/internal/fsx/make_directory.mbt
+++ b/internal/fsx/make_directory.mbt
@@ -12,7 +12,7 @@ pub async fn make_directory(
 ) -> Unit {
   let dirs = []
   for dir = path {
-    let dir = dir.to_string()
+    let dir = dir.to_owned()
     if dir == "." || dir == "" || @fs.exists(dir) {
       break
     }

--- a/internal/fsx/read_file.mbt
+++ b/internal/fsx/read_file.mbt
@@ -4,5 +4,5 @@
 /// This is a small convenience wrapper around `@fs.read_file` that reads
 /// all bytes from the file and decodes them as UTF-8 text.
 pub async fn read_file(path : StringView) -> String {
-  @fs.read_file(path.to_string()).text()
+  @fs.read_file(path.to_owned()).text()
 }

--- a/internal/fsx/remove.mbt
+++ b/internal/fsx/remove.mbt
@@ -4,5 +4,5 @@
 /// This delegates to `@fs.remove` and will raise on failure according to
 /// the underlying implementation.
 pub async fn remove(path : StringView) -> Unit {
-  @fs.remove(path.to_string())
+  @fs.remove(path.to_owned())
 }

--- a/internal/fsx/resolve.mbt
+++ b/internal/fsx/resolve.mbt
@@ -4,5 +4,5 @@
 /// This follows symbolic links and resolves `.` and `..` segments using
 /// the underlying `@fs.realpath` implementation.
 pub async fn resolve(path : StringView) -> String {
-  @fs.realpath(path.to_string())
+  @fs.realpath(path.to_owned())
 }

--- a/internal/fsx/stat.mbt
+++ b/internal/fsx/stat.mbt
@@ -50,7 +50,7 @@ pub fn Stat::atime(self : Stat) -> Int64 {
 ///|
 /// Inspect the `FileKind` of the entry at `path`.
 pub async fn kind(path : StringView) -> FileKind {
-  FileKind::of_fs_file_kind(@fs.kind(path.to_string()))
+  FileKind::of_fs_file_kind(@fs.kind(path.to_owned()))
 }
 
 ///|

--- a/internal/fsx/write_file.mbt
+++ b/internal/fsx/write_file.mbt
@@ -8,7 +8,7 @@ pub async fn write_bytes_to_file(
   content : Bytes,
   create? : Int = 0o644,
 ) -> Unit {
-  @fs.write_file(path.to_string(), content, create~, truncate=true)
+  @fs.write_file(path.to_owned(), content, create~, truncate=true)
 }
 
 ///|

--- a/internal/fuzzy/search.mbt
+++ b/internal/fuzzy/search.mbt
@@ -11,7 +11,7 @@ fn try_exact_match(haystack : String, needle : String) -> MatchResult? {
   match haystack.find(needle) {
     Some(position) => {
       // Calculate line numbers for the match
-      let before_match = haystack[0:position].to_string()
+      let before_match = haystack[0:position].to_owned()
       let start_line = before_match.split("\n").to_array().length() - 1
       let needle_lines = needle.split("\n").to_array().length()
       let end_line = start_line + needle_lines - 1
@@ -39,10 +39,10 @@ fn try_line_by_line_match(haystack : String, needle : String) -> MatchResult? {
   let haystack_lines = haystack.split("\n").to_array()
   let needle_lines = needle.split("\n").to_array()
   let trimmed_haystack_lines = haystack_lines.map(fn(line) {
-    line.trim(char_set=" \t\r\n").to_string()
+    line.trim(char_set=" \t\r\n").to_owned()
   })
   let trimmed_needle_lines = needle_lines.map(fn(line) {
-    line.trim(char_set=" \t\r\n").to_string()
+    line.trim(char_set=" \t\r\n").to_owned()
   })
 
   // Filter out empty lines for comparison

--- a/internal/git/check_ignore.mbt
+++ b/internal/git/check_ignore.mbt
@@ -13,11 +13,11 @@ pub async fn check_ignore(
   if output.is_empty() {
     return []
   }
-  output.split("\n").map(line => line.to_string()).collect()
+  output.split("\n").map(line => line.to_owned()).collect()
 }
 
 ///|
 pub async fn is_ignored(path : StringView, cwd? : StringView) -> Bool {
   let ignored_paths = check_ignore([path], cwd?)
-  return ignored_paths.contains(path.to_string())
+  return ignored_paths.contains(path.to_owned())
 }

--- a/internal/git/git.mbt
+++ b/internal/git/git.mbt
@@ -51,7 +51,7 @@ pub async fn generate_git_diff(
       ],
       cwd=tmpdir,
     )
-    let output = process.stdout.trim().to_string()
+    let output = process.stdout.trim().to_owned()
     if line_number {
       add_line_number_to_diff(output)
     } else {

--- a/internal/git/line_number.mbt
+++ b/internal/git/line_number.mbt
@@ -85,7 +85,7 @@ fn add_line_number_to_diff(diff_text : String) -> String raise {
             "\{state.marker} \{original_line_number} \{modified_line_number} \\\{line}",
           )
         }
-        line => numbered_lines.push(line.to_string())
+        line => numbered_lines.push(line.to_owned())
       }
     } else if last_state is Some(state) && line is ['\\', .. line] {
       let number_width = @cmp.maximum(
@@ -124,9 +124,9 @@ fn add_line_number_to_diff(diff_text : String) -> String raise {
             modified_count,
             marker: ' ',
           })
-          numbered_lines.push(line.to_string())
+          numbered_lines.push(line.to_owned())
         }
-        line => numbered_lines.push(line.to_string())
+        line => numbered_lines.push(line.to_owned())
       }
     }
   }

--- a/internal/git/list_files.mbt
+++ b/internal/git/list_files.mbt
@@ -6,5 +6,5 @@ pub async fn list_files(cwd? : StringView) -> Array[String] {
   if output.is_empty() {
     return []
   }
-  output.split("\n").map(line => line.to_string()).collect()
+  output.split("\n").map(line => line.to_owned()).collect()
 }

--- a/internal/git/worktree_test.mbt
+++ b/internal/git/worktree_test.mbt
@@ -53,7 +53,7 @@ async test "add_worktree/new-branch" (t : @test.Test) {
 pub async fn rev_parse(commit : String, cwd? : StringView) -> String {
   let process = @spawn.spawn("git", ["rev-parse", commit], cwd?)
   process.check()
-  return process.stdout.trim().to_string()
+  return process.stdout.trim().to_owned()
 }
 
 ///|

--- a/internal/httpx/event_stream.mbt
+++ b/internal/httpx/event_stream.mbt
@@ -171,13 +171,13 @@ pub async fn EventStreamReader::read_event(self : EventStreamReader) -> Event? {
   while self.r.read_until("\n") is Some(line) {
     match line {
       [.. "event: ", .. event] => {
-        self.last_event = Some(event.to_string())
+        self.last_event = Some(event.to_owned())
         continue
       }
       [.. "data: ", .. data] => {
         let event = self.last_event
         self.last_event = None
-        return Some(Event::{ event, data: data.to_string() })
+        return Some(Event::{ event, data: data.to_owned() })
       }
       _ => continue
     }

--- a/internal/httpx/file_server.mbt
+++ b/internal/httpx/file_server.mbt
@@ -36,7 +36,7 @@ pub fn FileServer::path(self : FileServer) -> StringView {
 /// The resulting middleware only serves `GET` requests and falls back to the
 /// downstream handler when a file does not exist.
 pub fn FileServer::new(path : StringView) -> FileServer {
-  let self_path = path.to_string()
+  let self_path = path.to_owned()
   let middleware : Middleware = k => {
     (r, w) => {
       guard r.method_ is Get else {
@@ -45,7 +45,7 @@ pub fn FileServer::new(path : StringView) -> FileServer {
       }
       let path = match r.path {
         "/" => Path::join(self_path, "index.html").to_string()
-        ['/', .. path] => Path::join(self_path, path.to_string()).to_string()
+        ['/', .. path] => Path::join(self_path, path.to_owned()).to_string()
         _ => {
           w.write_header(@status.BadRequest)
           return
@@ -84,7 +84,7 @@ pub fn FileServer::new(path : StringView) -> FileServer {
     }
   }
   FileServer::{
-    path: path.to_string(),
+    path: path.to_owned(),
     middleware,
     handler: middleware(not_found),
   }

--- a/internal/httpx/pkg.generated.mbti
+++ b/internal/httpx/pkg.generated.mbti
@@ -54,8 +54,6 @@ pub fn FileServer::path(Self) -> StringView
 pub fn FileServer::set_not_found_handler(Self, Handler) -> Unit
 
 pub(all) struct Handler(async (RequestReader, ResponseWriter) -> Unit)
-#deprecated
-pub fn Handler::inner(Self) -> async (RequestReader, ResponseWriter) -> Unit
 
 type Header
 pub fn Header::add(Self, String, String) -> Unit
@@ -66,8 +64,6 @@ pub impl Show for Header
 pub impl ToJson for Header
 
 pub struct JsonRequestReader(RequestReader)
-#deprecated
-pub fn JsonRequestReader::inner(Self) -> RequestReader
 pub fn JsonRequestReader::new(RequestReader) -> Self
 pub async fn[T : @json.FromJson] JsonRequestReader::read(Self) -> T
 pub async fn JsonRequestReader::read_json(Self) -> Json
@@ -96,8 +92,6 @@ pub(all) struct Middleware((Handler) -> Handler)
 pub fn Middleware::chain(Self, Self) -> Self
 pub async fn Middleware::handle(Self, RequestReader, ResponseWriter) -> Unit
 pub fn Middleware::handler(Self) -> Handler
-#deprecated
-pub fn Middleware::inner(Self) -> (Handler) -> Handler
 
 pub struct RequestReader {
   body : &@io.Reader

--- a/internal/jsonx/pkg.generated.mbti
+++ b/internal/jsonx/pkg.generated.mbti
@@ -17,8 +17,6 @@ pub fn int64(Int64) -> Json
 // Types and methods
 pub(all) struct Object(Map[String, Json])
 pub fn Object::get(Self, String) -> Json?
-#deprecated
-pub fn Object::inner(Self) -> Map[String, Json]
 pub fn Object::iter2(Self) -> Iter2[String, Json]
 pub fn[T : @json.FromJson] Object::optional(Self, String, path~ : @json.JsonPath) -> T? raise @json.JsonDecodeError
 pub fn Object::optional_int64(Self, String, path~ : @json.JsonPath) -> Int64? raise @json.JsonDecodeError

--- a/internal/openai/ai.mbt
+++ b/internal/openai/ai.mbt
@@ -411,7 +411,7 @@ async fn ResponseStreamEventReader::read(
   for ;; {
     guard self.0.read_until("\n") is Some(line) else { return None }
     guard line is [.. "data: ", .. rest] else { continue }
-    let data = rest.trim().to_string()
+    let data = rest.trim().to_owned()
     if data == "[DONE]" {
       return Some(Completed)
     }
@@ -618,7 +618,7 @@ fn extract_first_json_block(content : String) -> String? {
     .split("```")
     .take(1)
     .next()
-    .map(s => s.trim(char_set=" \r\n\t").to_string())
+    .map(s => s.trim(char_set=" \r\n\t").to_owned())
   })
 }
 

--- a/internal/openai/json.mbt
+++ b/internal/openai/json.mbt
@@ -104,7 +104,7 @@ pub impl ToChatCompletionMessageParamContent for String with to_chat_completion_
 pub impl ToChatCompletionMessageParamContent for StringView with to_chat_completion_message_param_content(
   self : StringView,
 ) -> Array[ChatCompletionContentPartParam] {
-  [text_content_part(self.to_string())]
+  [text_content_part(self.to_owned())]
 }
 
 ///|

--- a/internal/openai/uri.mbt
+++ b/internal/openai/uri.mbt
@@ -11,12 +11,12 @@ priv suberror InvalidUri
 ///|
 fn Uri::parse(string : String) -> Uri raise InvalidUri {
   guard string.find("://") is Some(protocol_len) else { raise InvalidUri }
-  let schema = string[:protocol_len].to_string()
+  let schema = string[:protocol_len].to_owned()
   let uri = string[protocol_len + 3:]
   let (host, path) = if uri.find("/") is Some(i) {
-    (uri[:i].to_string(), uri[i:].to_string())
+    (uri[:i].to_owned(), uri[i:].to_owned())
   } else {
-    (uri.to_string(), "/".to_string())
+    (uri.to_owned(), "/".to_string())
   }
   { schema, host, path: if path == "" { "/" } else { path } }
 }

--- a/internal/pathx/path.mbt
+++ b/internal/pathx/path.mbt
@@ -31,7 +31,7 @@ pub fn basename(path : StringView) -> StringView {
 ///
 /// property: `stem(path) + ext(path) == basename(path)`
 fn ext(path : StringView) -> StringView {
-  Path::extname(path.to_string())
+  Path::extname(path.to_owned())
 }
 
 ///|
@@ -53,9 +53,9 @@ fn ext(path : StringView) -> StringView {
 pub fn replace_ext(path : StringView, ext : StringView) -> String {
   let basename = basename(path)
   match basename {
-    "" => return path.to_string()
-    "." => return path.to_string()
-    ".." => return path.to_string()
+    "" => return path.to_owned()
+    "." => return path.to_owned()
+    ".." => return path.to_owned()
     _ => {
       let old_ext_len = match basename.rev_find(".") {
         None => 0

--- a/internal/pino/transport.mbt
+++ b/internal/pino/transport.mbt
@@ -63,7 +63,7 @@ pub fn Transport::parse(transport : StringView) -> Transport raise {
 async fn mkdir(path : String) -> Unit {
   let dirs = []
   for dir = path.view() {
-    let dir = dir.to_string()
+    let dir = dir.to_owned()
     if dir == "." || dir == "" || @fs.exists(dir) {
       break
     }
@@ -150,7 +150,7 @@ pub fn Transport::console() -> Transport {
 /// # Returns
 /// A Transport configured for file output
 pub fn Transport::file(path : StringView) -> Transport {
-  Transport::File(path=path.to_string(), file=None)
+  Transport::File(path=path.to_owned(), file=None)
 }
 
 ///|

--- a/internal/readline/readline.mbt
+++ b/internal/readline/readline.mbt
@@ -644,7 +644,7 @@ fn word_size_left(string : BytesView, index : Int) -> Int {
     return 0
   }
   let reversed = string[:index]
-    .to_bytes()
+    .to_owned()
     .to_fixedarray()
     .rev()
     .unsafe_reinterpret_as_bytes()
@@ -661,7 +661,7 @@ fn word_right_left(string : BytesView, index : Int) -> Int {
     return 0
   }
   let forward = string[index:]
-    .to_bytes()
+    .to_owned()
     .to_fixedarray()
     .unsafe_reinterpret_as_bytes()
   lexmatch forward with longest {
@@ -677,7 +677,7 @@ async fn Interface::delete_word_left(self : Interface) -> Unit {
     self.before_edit(self.line, self.cursor)
     let leading = self.line[:self.cursor]
     let reversed = leading
-      .to_bytes()
+      .to_owned()
       .to_fixedarray()
       .rev()
       .unsafe_reinterpret_as_bytes()

--- a/internal/rules/loader.mbt
+++ b/internal/rules/loader.mbt
@@ -27,7 +27,7 @@ async fn Loader::load_rules_from_directory(
     e.kind is @fsx.FileKind::Regular && e.name.has_suffix(".md")
   })
   for rule_path in dir {
-    let name = @pathx.stem(rule_path.name).to_string()
+    let name = @pathx.stem(rule_path.name).to_owned()
     self.rules[name] = Rule::parse(@fsx.read_file(rule_path.path), source~)
   }
 }

--- a/internal/skills/skill.mbt
+++ b/internal/skills/skill.mbt
@@ -106,7 +106,7 @@ fn parse_skill_from_content(
     _ => None
   }
   let allowed_tools : Array[String] = match meta.get("allowed-tools") {
-    Some(String(s)) => s.split(" ").map(tool => tool.to_string()).collect()
+    Some(String(s)) => s.split(" ").map(tool => tool.to_owned()).collect()
     Some(s) =>
       @json.from_json(s) catch {
         _ =>

--- a/internal/spawn/spawn.mbt
+++ b/internal/spawn/spawn.mbt
@@ -82,9 +82,9 @@ pub async fn spawn(
   cwd? : StringView,
   env? : Map[String, String],
 ) -> CompletedProcess {
-  let command = command.to_string()
-  let arguments = arguments.map(arg => arg.to_string())
-  let cwd = cwd.map(cwd => cwd.to_string())
+  let command = command.to_owned()
+  let arguments = arguments.map(arg => arg.to_owned())
+  let cwd = cwd.map(cwd => cwd.to_owned())
   @async.with_task_group(group => {
     fn redirect_input(content : String) -> &@process.ProcessInput raise {
       let (input, pipe) = @process.write_to_process()

--- a/internal/tiktoken/lexer_wbtest.mbt
+++ b/internal/tiktoken/lexer_wbtest.mbt
@@ -43,7 +43,7 @@ test (t : @test.Test) {
   let data = []
   for text in texts {
     let pieces = regexp_search_all(cl100k_base_regex, text).map(x => {
-      x.to_string()
+      x.to_owned()
     })
     data.push(LexerResult::{ text, pieces })
   }
@@ -57,7 +57,7 @@ test (t : @test.Test) {
 test (t : @test.Test) {
   let data = []
   for text in texts {
-    let pieces = regexp_search_all(r50k_regex, text).map(x => x.to_string())
+    let pieces = regexp_search_all(r50k_regex, text).map(x => x.to_owned())
     data.push(LexerResult::{ text, pieces })
   }
   let snapshot_data = SnapshotData::{ data, }
@@ -70,9 +70,7 @@ test (t : @test.Test) {
 test (t : @test.Test) {
   let data = []
   for text in texts {
-    let pieces = regexp_search_all(o200k_base_regex, text).map(x => {
-      x.to_string()
-    })
+    let pieces = regexp_search_all(o200k_base_regex, text).map(x => x.to_owned())
     data.push(LexerResult::{ text, pieces })
   }
   let snapshot_data = SnapshotData::{ data, }

--- a/internal/tiktoken/openai_public.mbt
+++ b/internal/tiktoken/openai_public.mbt
@@ -6,7 +6,7 @@ pub fn cl100k_base() -> Encoding raise {
       continue
     }
     guard line.split(" ").collect() is [token, rank]
-    let token = @base64.decode(token.to_string())
+    let token = @base64.decode(token.to_owned())
     mergeable_ranks[token] = @string.parse_int(rank)
   }
   let special_tokens = {

--- a/internal/yamd/yamd.mbt
+++ b/internal/yamd/yamd.mbt
@@ -43,13 +43,13 @@ fn tokenize_markdown_with_yaml_front_matter(
 pub fn parse(content : String) -> Document raise @yaml.YamlError {
   let (front_matter, text) = tokenize_markdown_with_yaml_front_matter(content)
   if front_matter.is_empty() {
-    Document::{ meta: {}, text: text.to_string() }
+    Document::{ meta: {}, text: text.to_owned() }
   } else {
-    let yaml_value = Yaml::load_from_string(front_matter.to_string())[0]
+    let yaml_value = Yaml::load_from_string(front_matter.to_owned())[0]
     guard yaml_value.to_json() is Object(meta) else {
       abort("assume yaml value must be Map")
     }
-    let text = text.to_string()
+    let text = text.to_owned()
     Document::{ meta, text }
   }
 }

--- a/job/pkg.generated.mbti
+++ b/job/pkg.generated.mbti
@@ -14,8 +14,6 @@ pub suberror InvalidJobId {
 
 // Types and methods
 pub(all) struct Id(Int) derive(Eq, Hash)
-#deprecated
-pub fn Id::inner(Self) -> Int
 pub impl Show for Id
 pub impl ToJson for Id
 pub impl @json.FromJson for Id

--- a/model/loader.mbt
+++ b/model/loader.mbt
@@ -50,14 +50,14 @@ async fn Loader::load(self : Loader) -> Unit {
     @json.from_json(json)
   }
 
-  let project = Path::join(self.cwd.to_string(), ".moonagent")
+  let project = Path::join(self.cwd.to_owned(), ".moonagent")
     .join("models")
     .join("models.json")
     .to_string()
   if @fsx.exists(project) {
     self.models.append(load_from_path(project))
   }
-  let user = Path::join(self.home.to_string(), ".moonagent")
+  let user = Path::join(self.home.to_owned(), ".moonagent")
     .join("models")
     .join("models.json")
     .to_string()

--- a/oauth/codex/credentials.mbt
+++ b/oauth/codex/credentials.mbt
@@ -37,7 +37,7 @@ fn parse_jwt(token : String) -> Json raise Error {
   if parts.length() != 3 {
     raise ParseError("Invalid JWT format")
   }
-  let padded = add_base64_padding(parts[1].to_string())
+  let padded = add_base64_padding(parts[1].to_owned())
   let payload = @base64.decode(padded, url_safe=true) catch {
     err => {
       println("ERROR in base64.decode: \{err}")

--- a/tool/pkg.generated.mbti
+++ b/tool/pkg.generated.mbti
@@ -18,8 +18,6 @@ pub fn AgentTool::desc(Self) -> ToolDesc
 
 pub(all) struct JsonSchema(Json) derive(Eq, Show)
 pub fn JsonSchema::from_json(Json) -> Self
-#deprecated
-pub fn JsonSchema::inner(Self) -> Json
 pub impl ToJson for JsonSchema
 
 pub struct Tool {
@@ -40,8 +38,6 @@ pub struct ToolDesc {
 pub fn ToolDesc::to_openai(Self) -> @openai.ChatCompletionToolParam
 
 pub(all) struct ToolFn(async (Json) -> ToolResult noraise)
-#deprecated
-pub fn ToolFn::inner(Self) -> async (Json) -> ToolResult noraise
 
 pub enum ToolResult {
   Success(&ToolOutput)

--- a/tools/apply_patch/executor.mbt
+++ b/tools/apply_patch/executor.mbt
@@ -90,7 +90,7 @@ fn apply_chunks(
 ) -> String raise ApplyError {
   let lines : Array[String] = original
     .split("\n")
-    .map(fn(sv) { sv.to_string() })
+    .map(fn(sv) { sv.to_owned() })
     .collect()
   if lines.length() > 0 && lines[lines.length() - 1].is_empty() {
     let _ = lines.pop()

--- a/tools/apply_patch/parser.mbt
+++ b/tools/apply_patch/parser.mbt
@@ -32,20 +32,20 @@ const WHITESPACE = " \t\r\n"
 pub fn parse_patch(patch : String) -> ParsedPatch raise ParseError {
   let lines = patch
     .trim(chars=WHITESPACE)
-    .to_string()
+    .to_owned()
     .split("\n")
-    .map(fn(sv) { sv.to_string() })
+    .map(fn(sv) { sv.to_owned() })
     .collect()
   guard lines.length() >= 2 else {
     raise InvalidPatch("Patch must have at least Begin and End markers")
   }
-  let first = lines[0].trim(chars=" \t").to_string()
+  let first = lines[0].trim(chars=" \t").to_owned()
   guard first == BEGIN_PATCH_MARKER else {
     raise InvalidPatch(
       "The first line of the patch must be '\{BEGIN_PATCH_MARKER}'",
     )
   }
-  let last = lines[lines.length() - 1].trim(chars=" \t").to_string()
+  let last = lines[lines.length() - 1].trim(chars=" \t").to_owned()
   guard last == END_PATCH_MARKER else {
     raise InvalidPatch(
       "The last line of the patch must be '\{END_PATCH_MARKER}'",
@@ -55,7 +55,7 @@ pub fn parse_patch(patch : String) -> ParsedPatch raise ParseError {
   let mut i = 1
   let end = lines.length() - 1
   while i < end {
-    let line = lines[i].trim(chars=" \t").to_string()
+    let line = lines[i].trim(chars=" \t").to_owned()
     if line.is_empty() {
       i += 1
       continue
@@ -73,7 +73,7 @@ fn parse_one_hunk(
   start : Int,
   end : Int,
 ) -> (Hunk, Int) raise ParseError {
-  let first_line = lines[start].trim(chars=" \t").to_string()
+  let first_line = lines[start].trim(chars=" \t").to_owned()
   let line_number = start + 1
   if first_line.has_prefix(ADD_FILE_MARKER) {
     let path = first_line[ADD_FILE_MARKER.length():]
@@ -83,7 +83,7 @@ fn parse_one_hunk(
     while i < end {
       let line = lines[i]
       if line.has_prefix("+") {
-        contents.write_string(line[1:].to_string())
+        contents.write_string(line[1:].to_owned())
         contents.write_char('\n')
         parsed_lines += 1
         i += 1
@@ -92,25 +92,25 @@ fn parse_one_hunk(
       }
     }
     return (
-      AddFile(path=path.to_string(), contents=contents.to_string()),
+      AddFile(path=path.to_owned(), contents=contents.to_string()),
       parsed_lines,
     )
   }
   if first_line.has_prefix(DELETE_FILE_MARKER) {
     let path = first_line[DELETE_FILE_MARKER.length():]
-    return (DeleteFile(path=path.to_string()), 1)
+    return (DeleteFile(path=path.to_owned()), 1)
   }
   if first_line.has_prefix(UPDATE_FILE_MARKER) {
     let path = first_line[UPDATE_FILE_MARKER.length():]
     let mut i = start + 1
     let mut parsed_lines = 1
     let move_path : String? = if i < end {
-      let trimmed = lines[i].trim(chars=" \t").to_string()
+      let trimmed = lines[i].trim(chars=" \t").to_owned()
       if trimmed.has_prefix(MOVE_TO_MARKER) {
         let mp = trimmed[MOVE_TO_MARKER.length():]
         i += 1
         parsed_lines += 1
-        Some(mp.to_string())
+        Some(mp.to_owned())
       } else {
         None
       }
@@ -119,7 +119,7 @@ fn parse_one_hunk(
     }
     let chunks = []
     while i < end {
-      let line = lines[i].trim(chars=" \t").to_string()
+      let line = lines[i].trim(chars=" \t").to_owned()
       if line.is_empty() {
         i += 1
         parsed_lines += 1
@@ -144,10 +144,7 @@ fn parse_one_hunk(
         line_number~,
       )
     }
-    return (
-      UpdateFile(path=path.to_string(), move_path~, chunks~),
-      parsed_lines,
-    )
+    return (UpdateFile(path=path.to_owned(), move_path~, chunks~), parsed_lines)
   }
   raise InvalidHunk(
     message="'\{first_line}' is not a valid hunk header. Valid: '\{ADD_FILE_MARKER}{{path}}', '\{DELETE_FILE_MARKER}{{path}}', '\{UPDATE_FILE_MARKER}{{path}}'",
@@ -162,13 +159,13 @@ fn parse_update_chunk(
   end : Int,
   allow_missing_context : Bool,
 ) -> (UpdateFileChunk, Int) raise ParseError {
-  let first_line = lines[start].trim(chars=" \t").to_string()
+  let first_line = lines[start].trim(chars=" \t").to_owned()
   let line_number = start + 1
   let (change_context, start_index) : (String?, Int) = if first_line ==
     EMPTY_CHANGE_CONTEXT_MARKER {
     (None, 1)
   } else if first_line.has_prefix(CHANGE_CONTEXT_MARKER) {
-    (Some(first_line[CHANGE_CONTEXT_MARKER.length():].to_string()), 1)
+    (Some(first_line[CHANGE_CONTEXT_MARKER.length():].to_owned()), 1)
   } else if allow_missing_context {
     (None, 0)
   } else {
@@ -184,7 +181,7 @@ fn parse_update_chunk(
   let mut i = start + start_index
   while i < end {
     let line = lines[i]
-    let trimmed = line.trim(chars=" \t").to_string()
+    let trimmed = line.trim(chars=" \t").to_owned()
     if trimmed == EOF_MARKER {
       is_end_of_file = true
       parsed_lines += 1
@@ -202,12 +199,12 @@ fn parse_update_chunk(
     }
     match line[0] {
       ' ' => {
-        let content = line[1:].to_string()
+        let content = line[1:].to_owned()
         old_lines.push(content)
         new_lines.push(content)
       }
-      '+' => new_lines.push(line[1:].to_string())
-      '-' => old_lines.push(line[1:].to_string())
+      '+' => new_lines.push(line[1:].to_owned())
+      '-' => old_lines.push(line[1:].to_owned())
       _ => {
         if parsed_lines == 0 {
           raise InvalidHunk(

--- a/tools/read_file/read_file.mbt
+++ b/tools/read_file/read_file.mbt
@@ -41,7 +41,7 @@ pub impl Show for ReadFileToolResult with output(
       let selected_lines = if lines.length() == expected_lines {
         lines
       } else {
-        lines[start_line - 1:end_line].to_array()
+        lines[start_line - 1:end_line].to_owned()
       }
       let width = end_line.to_string().length()
       let selected_content = selected_lines

--- a/tools/replace_in_file/replace_in_file.mbt
+++ b/tools/replace_in_file/replace_in_file.mbt
@@ -99,8 +99,8 @@ async fn @file.Manager::execute_replace_in_file(
             )
           Some(match_result) => {
             // Replace at the exact position to maintain formatting
-            let before = content[0:match_result.position].to_string()
-            let after = content[match_result.position + match_result.length:].to_string()
+            let before = content[0:match_result.position].to_owned()
+            let after = content[match_result.position + match_result.length:].to_owned()
             before + replace + after
           }
         }

--- a/tools/search_files/tool.mbt
+++ b/tools/search_files/tool.mbt
@@ -93,7 +93,7 @@ fn matches_pattern(filename : String, pattern : String) -> Bool {
 
   // Handle simple *.ext patterns
   if pattern.has_prefix("*.") {
-    let extension = pattern[2:].to_string()
+    let extension = pattern[2:].to_owned()
     return filename.has_suffix(".\{extension}")
   }
 
@@ -138,7 +138,7 @@ async fn search_in_file(
       let result = SearchResult::{
         context: context_lines_arr.join("\n"),
         line_number: i + 1,
-        match_line: line.to_string(), // Convert StringView to String
+        match_line: line.to_owned(), // Convert StringView to String
         path: relative_path,
       }
       results.push(result)

--- a/tools/todo/manager.mbt
+++ b/tools/todo/manager.mbt
@@ -8,7 +8,7 @@ fn Todo::todos(self : Todo) -> ArrayView[Item] {
 
 ///|
 fn Config::uuid(self : Config) -> String {
-  self.uuid.v4().to_string()[:8].to_string()
+  self.uuid.v4().to_string()[:8].to_owned()
 }
 
 ///|
@@ -63,7 +63,7 @@ pub fn new(
   cwd~ : StringView,
 ) -> Todo {
   Todo::{
-    config: { uuid, clock, cwd: cwd.to_string() },
+    config: { uuid, clock, cwd: cwd.to_owned() },
     items: {
       todos: [],
       created_at: clock.now_str(),
@@ -245,7 +245,7 @@ fn Items::parse(
       let trimmed = task_content.trim(char_set=" \t\r\n")
       if trimmed.length() > 0 {
         let todo = Item::new(
-          content=trimmed.to_string(),
+          content=trimmed.to_owned(),
           notes?,
           priority~,
           status=Pending,
@@ -268,7 +268,7 @@ fn Items::parse(
       let clean_line = remove_list_prefixes(trimmed_line)
       if clean_line.length() > 0 {
         let todo = Item::new(
-          content=clean_line.to_string(),
+          content=clean_line.to_owned(),
           notes?,
           priority~,
           status=Pending,


### PR DESCRIPTION
## Summary
- Replaces deprecated `.to_string()` on StringView/BytesView with `.to_owned()` (~101 sites)
- Replaces one deprecated `.to_array()` with `.to_owned()`

## Test plan
- [x] `moon check` confirms 0 to_owned/to_array warnings remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)