### PR TITLE
fix: replace deprecated derive(Show) with derive(Debug)

### DIFF
--- a/ai/message.mbt
+++ b/ai/message.mbt
@@ -4,7 +4,7 @@ pub enum Message {
   System(String)
   Assistant(String, tool_calls~ : Array[ToolCall])
   Tool(String, tool_call_id~ : String)
-} derive(ToJson, Eq, Show)
+} derive(ToJson, Eq, Debug)
 
 ///|
 pub fn user_message(content~ : String) -> Message {
@@ -44,7 +44,7 @@ pub struct ToolCall {
   id : String
   name : String
   arguments : String?
-} derive(ToJson, Eq, Show)
+} derive(ToJson, Eq, Debug)
 
 ///|
 pub fn tool_call(id~ : String, name~ : String, arguments? : String) -> ToolCall {
@@ -57,7 +57,7 @@ pub struct Usage {
   output_tokens : Int
   total_tokens : Int
   cache_read_tokens : Int?
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub fn usage(

--- a/ai/pkg.generated.mbti
+++ b/ai/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/ai"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/maria/internal/openai",
 }
 
@@ -26,7 +27,7 @@ pub enum Message {
   System(String)
   Assistant(String, tool_calls~ : Array[ToolCall])
   Tool(String, tool_call_id~ : String)
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn Message::content(Self) -> String
 pub fn Message::from_openai(@openai.ChatCompletionMessageParam) -> Self
 pub fn Message::from_openai_response(@openai.ChatCompletionMessage) -> Self
@@ -36,7 +37,7 @@ pub struct ToolCall {
   id : String
   name : String
   arguments : String?
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn ToolCall::from_openai_tool_call(@openai.ChatCompletionMessageToolCall) -> Self
 pub fn ToolCall::to_openai(Self) -> @openai.ChatCompletionMessageToolCall
 
@@ -45,7 +46,7 @@ pub struct Usage {
   output_tokens : Int
   total_tokens : Int
   cache_read_tokens : Int?
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub fn Usage::from_openai(@openai.CompletionUsage) -> Self
 pub fn Usage::to_openai(Self) -> @openai.CompletionUsage
 

--- a/clock/moon.pkg
+++ b/clock/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbitlang/async",
   "moonbitlang/x/time",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbitlang/core/strconv",

--- a/clock/pkg.generated.mbti
+++ b/clock/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/clock"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -21,6 +22,7 @@ pub fn Timestamp::ms_since(Self, Self) -> Int64
 pub fn Timestamp::truncate_to_s(Self) -> Int64
 pub impl Show for Timestamp
 pub impl ToJson for Timestamp
+pub impl @debug.Debug for Timestamp
 pub impl @json.FromJson for Timestamp
 
 // Type aliases

--- a/clock/timestamp.mbt
+++ b/clock/timestamp.mbt
@@ -9,6 +9,11 @@ pub impl Show for Timestamp with output(self : Timestamp, logger : &Logger) -> U
 }
 
 ///|
+pub impl @debug.Debug for Timestamp with to_repr(self : Timestamp) -> @debug.Repr {
+  @debug.Repr::integer(self.0.to_string())
+}
+
+///|
 /// Creates a new timestamp from the given number of milliseconds since the Unix
 /// epoch.
 ///

--- a/cmd/daemon/moon.pkg
+++ b/cmd/daemon/moon.pkg
@@ -27,6 +27,7 @@ import {
   "moonbitlang/maria/ai",
   "moonbitlang/maria/oauth/codex",
   "moonbitlang/maria/oauth/copilot",
+  "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8" @encoding/utf8,
   "moonbitlang/core/json",
   "moonbitlang/core/string",

--- a/cmd/daemon/task_running.mbt
+++ b/cmd/daemon/task_running.mbt
@@ -96,7 +96,7 @@ impl @json.FromJson for Running with from_json(
           raise @json.JsonDecodeError(
             (
               json_path.add_key("id"),
-              "Task::from_json: invalid UUID string: \{error}",
+              "Task::from_json: invalid UUID string: " + @debug.to_string(error),
             ),
           )
       }

--- a/cmd/main/argument/error.mbt
+++ b/cmd/main/argument/error.mbt
@@ -1,4 +1,4 @@
 ///|
 pub(all) suberror InvalidArgument {
   InvalidArgument(String)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)

--- a/cmd/main/argument/pkg.generated.mbti
+++ b/cmd/main/argument/pkg.generated.mbti
@@ -1,12 +1,16 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/maria/cmd/main/argument"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 
 // Errors
 pub(all) suberror InvalidArgument {
   InvalidArgument(String)
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 // Types and methods
 

--- a/event/event.mbt
+++ b/event/event.mbt
@@ -31,7 +31,7 @@ pub struct Event {
   id : @uuid.Uuid
   created : @clock.Timestamp
   desc : EventDesc
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 /// Creates a new `Event` with the specified parameters.
@@ -114,7 +114,7 @@ pub(all) enum EventDesc {
   /// Event triggered when a PostToolCall event is pruned from context.
   /// The `id` field references the pruned PostToolCall event's id.
   Pruned(id~ : @uuid.Uuid)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub impl ToJson for EventDesc with to_json(self : EventDesc) -> Json {

--- a/event/event_test.mbt
+++ b/event/event_test.mbt
@@ -600,7 +600,7 @@ test "Event::Roundtrip/AssistantMessage/WithUsage" {
     },
   })
   let roundtripped : @event.EventDesc = @json.from_json(json)
-  assert_eq(roundtripped, event)
+  @debug.assert_eq(roundtripped, event)
 }
 
 ///|
@@ -614,7 +614,7 @@ test "Event::Roundtrip/AssistantMessage/NoUsage" {
   )
   let json = event.to_json()
   let roundtripped : @event.EventDesc = @json.from_json(json)
-  assert_eq(roundtripped, event)
+  @debug.assert_eq(roundtripped, event)
 }
 
 ///|
@@ -709,6 +709,6 @@ test "Event::Roundtrip" {
   for event in events {
     let event = @event.Event::new(id=uuid.v4(), event)
     let roundtripped : @event.Event = @json.from_json(event.to_json())
-    assert_eq(roundtripped, event)
+    @debug.assert_eq(roundtripped, event)
   }
 }

--- a/event/moon.pkg
+++ b/event/moon.pkg
@@ -7,6 +7,7 @@ import {
   "moonbitlang/maria/internal/rand",
   "moonbitlang/maria/clock",
   "moonbitlang/maria/internal/jsonx",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/test",
 }

--- a/event/pkg.generated.mbti
+++ b/event/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/event"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/maria/ai",
   "moonbitlang/maria/clock",
@@ -18,7 +19,7 @@ pub struct Event {
   id : @uuid.Uuid
   created : @clock.Timestamp
   desc : EventDesc
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub fn Event::is_cancellation(Self) -> Bool
 pub fn Event::is_incoming(Self) -> Bool
 pub fn Event::is_starting(Self) -> Bool
@@ -44,7 +45,7 @@ pub(all) enum EventDesc {
   Cancelled
   Failed(Json)
   Pruned(id~ : @uuid.Uuid)
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub impl ToJson for EventDesc
 pub impl @json.FromJson for EventDesc
 

--- a/internal/assets/assets.mbt
+++ b/internal/assets/assets.mbt
@@ -6,7 +6,7 @@ using @path {type Path}
 pub(all) struct Asset {
   path : String
   content : String
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// Installs embedded assets into `root`, guarded by a marker fingerprint.

--- a/internal/assets/pkg.generated.mbti
+++ b/internal/assets/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/internal/assets"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/maria/internal/pino",
 }
 
@@ -14,7 +15,7 @@ pub async fn install_assets(String, Array[Asset], String, String, @pino.Logger) 
 pub(all) struct Asset {
   path : String
   content : String
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 // Type aliases
 

--- a/internal/fsx/list_directory.mbt
+++ b/internal/fsx/list_directory.mbt
@@ -15,7 +15,7 @@ pub enum FileKind {
   Pipe
   BlockDevice
   CharDevice
-} derive(Show, Hash, Eq, Compare, ToJson)
+} derive(Debug, Hash, Eq, Compare, ToJson)
 
 ///|
 fn FileKind::of_fs_file_kind(file_kind : @fs.FileKind) -> FileKind {
@@ -44,7 +44,7 @@ pub struct DirectoryEntry {
   name : String
   /// File-system kind of the entry.
   kind : FileKind
-} derive(Show, Hash, Eq, Compare, ToJson)
+} derive(Debug, Hash, Eq, Compare, ToJson)
 
 ///|
 /// List all entries in the directory at `path`.

--- a/internal/fsx/pkg.generated.mbti
+++ b/internal/fsx/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/maria/internal/fsx"
 
 import {
   "moonbitlang/async/fs",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -47,7 +48,7 @@ pub struct DirectoryEntry {
   path : String
   name : String
   kind : FileKind
-} derive(Compare, Eq, Hash, Show, ToJson)
+} derive(Compare, Eq, Hash, ToJson, @debug.Debug)
 
 pub enum FileKind {
   Unknown
@@ -58,7 +59,7 @@ pub enum FileKind {
   Pipe
   BlockDevice
   CharDevice
-} derive(Compare, Eq, Hash, Show, ToJson)
+} derive(Compare, Eq, Hash, ToJson, @debug.Debug)
 
 type FileRead
 pub fn FileRead::close(Self) -> Unit

--- a/internal/openai/ai.mbt
+++ b/internal/openai/ai.mbt
@@ -1,7 +1,7 @@
 ///|
 priv suberror HttpError {
   HttpError(code~ : Int, body~ : String)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// Execute a chat completion request with the OpenAI API.

--- a/internal/openai/chat_completion.mbt
+++ b/internal/openai/chat_completion.mbt
@@ -8,7 +8,7 @@ pub struct ChatCompletion {
   usage : CompletionUsage?
   system_fingerprint : String?
   service_tier : ChatCompletionServiceTier?
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn ChatCompletion::new(

--- a/internal/openai/chat_completion_choice.mbt
+++ b/internal/openai/chat_completion_choice.mbt
@@ -4,7 +4,7 @@ pub struct ChatCompletionChoice {
   finish_reason : ChatCompletionChoiceFinishReason?
   index : Int
   message : ChatCompletionMessage
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn ChatCompletionChoice::new(

--- a/internal/openai/chat_completion_choice_finish_reason.mbt
+++ b/internal/openai/chat_completion_choice_finish_reason.mbt
@@ -6,7 +6,7 @@ pub(all) enum ChatCompletionChoiceFinishReason {
   ToolCalls
   ContentFilter
   FunctionCall
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl ToJson for ChatCompletionChoiceFinishReason with to_json(

--- a/internal/openai/chat_completion_message.mbt
+++ b/internal/openai/chat_completion_message.mbt
@@ -5,7 +5,7 @@ pub struct ChatCompletionMessage {
   refusal : String?
   role : ChatCompletionMessageRole
   tool_calls : Array[ChatCompletionMessageToolCall]
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn ChatCompletionMessage::new(

--- a/internal/openai/chat_completion_message_role.mbt
+++ b/internal/openai/chat_completion_message_role.mbt
@@ -2,7 +2,7 @@
 /// Message author roles reflected in completion responses.
 pub enum ChatCompletionMessageRole {
   Assistant
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub impl ToJson for ChatCompletionMessageRole with to_json(

--- a/internal/openai/chat_completion_message_tool_call.mbt
+++ b/internal/openai/chat_completion_message_tool_call.mbt
@@ -4,7 +4,7 @@
 pub struct ChatCompletionMessageToolCall {
   id : String
   function : ChatCompletionMessageToolCallFunction
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub impl ToJson for ChatCompletionMessageToolCall with to_json(

--- a/internal/openai/chat_completion_message_tool_call_function.mbt
+++ b/internal/openai/chat_completion_message_tool_call_function.mbt
@@ -3,7 +3,7 @@
 pub struct ChatCompletionMessageToolCallFunction {
   arguments : String?
   name : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl ToJson for ChatCompletionMessageToolCallFunction with to_json(

--- a/internal/openai/chat_completion_reasoning_effort.mbt
+++ b/internal/openai/chat_completion_reasoning_effort.mbt
@@ -7,7 +7,7 @@ pub(all) enum ChatCompletionReasoningEffort {
   Medium
   High
   Xhigh
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl ToJson for ChatCompletionReasoningEffort with to_json(

--- a/internal/openai/chat_completion_service_tier.mbt
+++ b/internal/openai/chat_completion_service_tier.mbt
@@ -7,7 +7,7 @@ pub(all) enum ChatCompletionServiceTier {
   Flex
   Scale
   Priority
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl @json.FromJson for ChatCompletionServiceTier with from_json(

--- a/internal/openai/completion_tokens_details.mbt
+++ b/internal/openai/completion_tokens_details.mbt
@@ -2,7 +2,7 @@
 /// Token usage details for the model-completion segment.
 pub struct CompletionTokensDetails {
   reasoning_tokens : Int?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 impl @json.FromJson for CompletionTokensDetails with from_json(

--- a/internal/openai/completion_usage.mbt
+++ b/internal/openai/completion_usage.mbt
@@ -8,7 +8,7 @@ pub struct CompletionUsage {
   prompt_tokens : Int
   prompt_tokens_details : PromptTokensDetails?
   total_tokens : Int
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn CompletionUsage::new(

--- a/internal/openai/cost_details.mbt
+++ b/internal/openai/cost_details.mbt
@@ -2,7 +2,7 @@
 /// Detailed billing information for a request.
 pub struct CostDetails {
   upstream_inference_cost : Double?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 impl @json.FromJson for CostDetails with from_json(

--- a/internal/openai/pkg.generated.mbti
+++ b/internal/openai/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/internal/openai"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/maria/internal/pino",
   "moonbitlang/maria/internal/schema",
@@ -65,7 +66,7 @@ pub struct ChatCompletion {
   usage : CompletionUsage?
   system_fingerprint : String?
   service_tier : ChatCompletionServiceTier?
-} derive(Show)
+} derive(@debug.Debug)
 pub fn ChatCompletion::new(id~ : String, choices~ : Array[ChatCompletionChoice], created~ : Int, model~ : String, usage? : CompletionUsage, system_fingerprint? : String, service_tier? : ChatCompletionServiceTier) -> Self
 pub impl ToJson for ChatCompletion
 pub impl @json.FromJson for ChatCompletion
@@ -90,7 +91,7 @@ pub struct ChatCompletionChoice {
   finish_reason : ChatCompletionChoiceFinishReason?
   index : Int
   message : ChatCompletionMessage
-} derive(Show)
+} derive(@debug.Debug)
 pub fn ChatCompletionChoice::new(finish_reason? : ChatCompletionChoiceFinishReason, index~ : Int, message~ : ChatCompletionMessage) -> Self
 
 pub(all) enum ChatCompletionChoiceFinishReason {
@@ -99,7 +100,7 @@ pub(all) enum ChatCompletionChoiceFinishReason {
   ToolCalls
   ContentFilter
   FunctionCall
-} derive(Show)
+} derive(@debug.Debug)
 
 pub struct ChatCompletionChunk {
   id : String
@@ -162,7 +163,7 @@ pub struct ChatCompletionMessage {
   refusal : String?
   role : ChatCompletionMessageRole
   tool_calls : Array[ChatCompletionMessageToolCall]
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn ChatCompletionMessage::new(content? : String, refusal? : String, role? : ChatCompletionMessageRole, tool_calls? : Array[ChatCompletionMessageToolCall]) -> Self
 pub fn ChatCompletionMessage::to_param(Self) -> ChatCompletionMessageParam
 pub impl @json.FromJson for ChatCompletionMessage
@@ -178,21 +179,21 @@ pub impl @json.FromJson for ChatCompletionMessageParam
 
 pub enum ChatCompletionMessageRole {
   Assistant
-} derive(Show)
+} derive(@debug.Debug)
 pub impl ToJson for ChatCompletionMessageRole
 
 #alias(ChatCompletionMessageToolCallParam)
 pub struct ChatCompletionMessageToolCall {
   id : String
   function : ChatCompletionMessageToolCallFunction
-} derive(Show)
+} derive(@debug.Debug)
 pub impl ToJson for ChatCompletionMessageToolCall
 pub impl @json.FromJson for ChatCompletionMessageToolCall
 
 pub struct ChatCompletionMessageToolCallFunction {
   arguments : String?
   name : String
-} derive(Show)
+} derive(@debug.Debug)
 
 pub(all) enum ChatCompletionReasoningEffort {
   None_
@@ -201,7 +202,7 @@ pub(all) enum ChatCompletionReasoningEffort {
   Medium
   High
   Xhigh
-} derive(Show)
+} derive(@debug.Debug)
 
 pub(all) enum ChatCompletionRole {
   Developer
@@ -218,7 +219,7 @@ pub(all) enum ChatCompletionServiceTier {
   Flex
   Scale
   Priority
-} derive(Show)
+} derive(@debug.Debug)
 
 pub struct ChatCompletionStreamOptionsParam {
   include_obfuscation : Bool?
@@ -258,7 +259,7 @@ pub fn ChatCompletionUserMessageParam::new(content~ : Array[ChatCompletionConten
 
 pub struct CompletionTokensDetails {
   reasoning_tokens : Int?
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub struct CompletionUsage {
   completion_tokens : Int
@@ -268,7 +269,7 @@ pub struct CompletionUsage {
   prompt_tokens : Int
   prompt_tokens_details : PromptTokensDetails?
   total_tokens : Int
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn CompletionUsage::new(completion_tokens~ : Int, completion_tokens_details? : CompletionTokensDetails, cost? : Double, cost_details? : CostDetails, prompt_tokens~ : Int, prompt_tokens_details? : PromptTokensDetails, total_tokens~ : Int) -> Self
 pub impl @json.FromJson for CompletionUsage
 
@@ -278,7 +279,7 @@ pub struct CompletionUsageParam {
 
 pub struct CostDetails {
   upstream_inference_cost : Double?
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub struct FunctionDefinition {
   name : String
@@ -299,7 +300,7 @@ pub impl @json.FromJson for OpenRouterErrorResponse
 pub struct PromptTokensDetails {
   cached_tokens : Int?
   audio_tokens : Int?
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 pub fn PromptTokensDetails::new(cached_tokens? : Int, audio_tokens? : Int) -> Self
 
 pub struct Request {

--- a/internal/openai/prompt_tokens_details.mbt
+++ b/internal/openai/prompt_tokens_details.mbt
@@ -3,7 +3,7 @@
 pub struct PromptTokensDetails {
   cached_tokens : Int?
   audio_tokens : Int?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn PromptTokensDetails::new(

--- a/internal/openai/responses/pkg.generated.mbti
+++ b/internal/openai/responses/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/internal/openai/responses"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -16,7 +17,7 @@ pub fn message_input(role~ : String, content~ : String) -> ResponseInputItem
 pub struct ContentPart {
   type_ : ContentType
   text : String
-} derive(Show)
+} derive(@debug.Debug)
 pub fn ContentPart::new(type_~ : ContentType, text~ : String) -> Self
 pub impl ToJson for ContentPart
 pub impl @json.FromJson for ContentPart
@@ -25,7 +26,7 @@ pub(all) enum ContentType {
   InputText
   OutputText
   Text
-} derive(Show)
+} derive(@debug.Debug)
 pub impl ToJson for ContentType
 pub impl @json.FromJson for ContentType
 
@@ -33,13 +34,13 @@ pub(all) enum ResponseInputItem {
   Message(role~ : String, content~ : Array[ContentPart])
   FunctionCall(call_id~ : String, name~ : String, arguments~ : String)
   FunctionCallOutput(call_id~ : String, output~ : String)
-} derive(Show)
+} derive(@debug.Debug)
 pub impl ToJson for ResponseInputItem
 
 pub(all) enum ResponseItem {
   Message(role~ : String, content~ : Array[ContentPart])
   FunctionCall(call_id~ : String, name~ : String, arguments~ : String)
-} derive(Show)
+} derive(@debug.Debug)
 pub impl @json.FromJson for ResponseItem
 
 pub struct ResponsesRequest {
@@ -50,7 +51,7 @@ pub struct ResponsesRequest {
   tool_choice : String
   stream : Bool?
   store : Bool?
-} derive(Show)
+} derive(@debug.Debug)
 pub fn ResponsesRequest::new(model~ : String, input~ : Array[ResponseInputItem], instructions~ : String, tools? : Array[Json], tool_choice? : String, stream? : Bool, store? : Bool) -> Self
 pub impl ToJson for ResponsesRequest
 

--- a/internal/openai/responses/types.mbt
+++ b/internal/openai/responses/types.mbt
@@ -13,7 +13,7 @@ pub struct ResponsesRequest {
   tool_choice : String
   stream : Bool?
   store : Bool?
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// This is the minimal subset of Responses API content we currently need.
@@ -21,7 +21,7 @@ pub(all) enum ContentType {
   InputText
   OutputText
   Text
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub impl ToJson for ContentType with to_json(self : ContentType) -> Json {
@@ -53,7 +53,7 @@ pub impl @json.FromJson for ContentType with from_json(
 pub struct ContentPart {
   type_ : ContentType
   text : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn ContentPart::new(type_~ : ContentType, text~ : String) -> ContentPart {
@@ -122,7 +122,7 @@ pub(all) enum ResponseInputItem {
   Message(role~ : String, content~ : Array[ContentPart])
   FunctionCall(call_id~ : String, name~ : String, arguments~ : String)
   FunctionCallOutput(call_id~ : String, output~ : String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub impl ToJson for ResponseInputItem with to_json(self : ResponseInputItem) -> Json {
@@ -145,7 +145,7 @@ pub impl ToJson for ResponseInputItem with to_json(self : ResponseInputItem) -> 
 pub(all) enum ResponseItem {
   Message(role~ : String, content~ : Array[ContentPart])
   FunctionCall(call_id~ : String, name~ : String, arguments~ : String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub impl @json.FromJson for ResponseItem with from_json(

--- a/internal/pino/level.mbt
+++ b/internal/pino/level.mbt
@@ -21,7 +21,7 @@ pub(all) enum Level {
   Warn
   Error
   Fatal
-} derive(Show, Eq, Compare, ToJson)
+} derive(Debug, Eq, Compare, ToJson)
 
 ///|
 test {

--- a/internal/pino/pkg.generated.mbti
+++ b/internal/pino/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "moonbitlang/maria/internal/pino"
 
 import {
   "moonbitlang/async/aqueue",
+  "moonbitlang/core/debug",
 }
 
 // Values
@@ -18,7 +19,7 @@ pub(all) enum Level {
   Warn
   Error
   Fatal
-} derive(Compare, Eq, Show, ToJson)
+} derive(Compare, Eq, ToJson, @debug.Debug)
 
 type Logger
 pub fn Logger::child(Self, Map[String, Json]) -> Self

--- a/internal/pino/transport.mbt
+++ b/internal/pino/transport.mbt
@@ -13,7 +13,7 @@ enum Transport {
 ///|
 priv suberror InvalidTransport {
   InvalidTransport(StringView)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Parses a transport string and creates the corresponding Transport instance.

--- a/internal/rules/loader.mbt
+++ b/internal/rules/loader.mbt
@@ -66,7 +66,7 @@ pub fn Loader::apply(self : Loader, messages : Array[@ai.Message]) -> Unit {
 pub enum Source {
   Global
   Local
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub struct Rule {
@@ -75,7 +75,7 @@ pub struct Rule {
   always_apply : Bool
   content : String
   source : Source
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 fn Rule::parse(content : String, source~ : Source) -> Rule raise {

--- a/internal/rules/pkg.generated.mbti
+++ b/internal/rules/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/internal/rules"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/maria/ai",
   "moonbitlang/maria/internal/pino",
 }
@@ -22,12 +23,12 @@ pub struct Rule {
   always_apply : Bool
   content : String
   source : Source
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub enum Source {
   Global
   Local
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 // Type aliases
 

--- a/internal/skills/pkg.generated.mbti
+++ b/internal/skills/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/internal/skills"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/maria/ai",
   "moonbitlang/maria/internal/pino",
 }
@@ -25,7 +26,7 @@ pub struct Skill {
   allowed_tools : Array[String]
   metadata : Json?
   location : String
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 // Type aliases
 

--- a/internal/skills/skill.mbt
+++ b/internal/skills/skill.mbt
@@ -9,7 +9,7 @@ pub struct Skill {
   allowed_tools : Array[String]
   metadata : Json?
   location : String
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 fn validate_name(
@@ -46,7 +46,7 @@ fn validate_description(desc : String) -> Unit raise SkillFormatError {
 ///|
 priv suberror SkillFormatError {
   SkillFormatError(String)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// Parses a skill definition from YAML frontmatter content and creates a

--- a/internal/tiktoken/encoding.mbt
+++ b/internal/tiktoken/encoding.mbt
@@ -217,7 +217,7 @@ pub fn Encoding::encode(self : Encoding, piece : StringView) -> Array[Int] {
 suberror DecodingError {
   InvalidToken(Int)
   MalformedUtf8(Bytes)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn Encoding::decode(

--- a/internal/tiktoken/pkg.generated.mbti
+++ b/internal/tiktoken/pkg.generated.mbti
@@ -1,11 +1,15 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/maria/internal/tiktoken"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 pub fn cl100k_base() -> Encoding raise
 
 // Errors
-type DecodingError derive(Show)
+type DecodingError derive(@debug.Debug)
 
 // Types and methods
 type Encoding

--- a/internal/uri/pkg.generated.mbti
+++ b/internal/uri/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "moonbitlang/maria/internal/uri"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
 
 // Errors
@@ -11,7 +15,7 @@ pub struct Authority {
   mut userinfo : StringView?
   mut host : StringView
   mut port : Int?
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 
 pub struct Uri {
   mut scheme : StringView
@@ -19,7 +23,7 @@ pub struct Uri {
   path : Array[StringView]
   mut query : StringView?
   mut fragment : StringView?
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub fn Uri::parse(StringView) -> Self raise ParseError
 
 // Type aliases

--- a/internal/uri/uri.mbt
+++ b/internal/uri/uri.mbt
@@ -5,7 +5,7 @@ pub struct Authority {
   mut userinfo : StringView?
   mut host : StringView
   mut port : Int?
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub struct Uri {
@@ -14,7 +14,7 @@ pub struct Uri {
   path : Array[StringView]
   mut query : StringView?
   mut fragment : StringView?
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 suberror ParseError {

--- a/internal/uuid/moon.pkg
+++ b/internal/uuid/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/random",
 }

--- a/internal/uuid/pkg.generated.mbti
+++ b/internal/uuid/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/internal/uuid"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/random",
 }
@@ -16,7 +17,7 @@ pub let nil : Uuid
 pub fn parse(StringView) -> Uuid raise ParseError
 
 // Errors
-type ParseError derive(Show, ToJson)
+type ParseError derive(ToJson, @debug.Debug)
 
 // Types and methods
 type Generator
@@ -31,6 +32,7 @@ pub fn Uuid::variant(Self) -> Variant
 pub fn Uuid::version(Self) -> Version?
 pub impl Show for Uuid
 pub impl ToJson for Uuid
+pub impl @debug.Debug for Uuid
 pub impl @json.FromJson for Uuid
 
 pub enum Variant {
@@ -38,7 +40,7 @@ pub enum Variant {
   RFC9562(Version)
   ReservedMicrosoft
   ReservedFuture
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 pub(all) enum Version {
   V0
@@ -57,7 +59,7 @@ pub(all) enum Version {
   V13
   V14
   V15
-} derive(Show, ToJson)
+} derive(ToJson, @debug.Debug)
 
 // Type aliases
 

--- a/internal/uuid/uuid.mbt
+++ b/internal/uuid/uuid.mbt
@@ -31,7 +31,9 @@ pub impl @json.FromJson for Uuid with from_json(json, json_path) -> Uuid raise {
   }
   parse(string) catch {
     error =>
-      raise @json.JsonDecodeError((json_path, "Uuid::from_json: \{error}"))
+      raise @json.JsonDecodeError(
+        (json_path, "Uuid::from_json: " + @debug.to_string(error)),
+      )
   }
 }
 
@@ -121,7 +123,7 @@ suberror ParseError {
   InvalidOctet(StringView)
   MissingDash(StringView)
   ExtraContent(StringView)
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub fn parse(hex : StringView) -> Uuid raise ParseError {
@@ -218,12 +220,17 @@ pub impl Show for Uuid with output(self : Uuid, logger : &Logger) -> Unit {
 }
 
 ///|
+pub impl @debug.Debug for Uuid with to_repr(self : Uuid) -> @debug.Repr {
+  @debug.Repr::string(self.to_string())
+}
+
+///|
 pub enum Variant {
   ReservedNCS
   RFC9562(Version)
   ReservedMicrosoft
   ReservedFuture
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 pub(all) enum Version {
@@ -243,7 +250,7 @@ pub(all) enum Version {
   V13 = 13
   V14 = 14
   V15 = 15
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 fn Version::from_uint64_unchecked(value : UInt64) -> Version = "%identity"

--- a/model/model.mbt
+++ b/model/model.mbt
@@ -14,19 +14,19 @@ pub struct Model {
   account_id : String?
   refresh_token : String?
   id_token : String?
-} derive(ToJson, Eq, Show)
+} derive(ToJson, Eq, Debug)
 
 ///|
 pub(all) enum Provider {
   OpenAI
   CodexOAuth
   Copilot
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 pub(all) enum Type {
   SaaS(Provider)
-} derive(Eq, Show)
+} derive(Eq, Debug)
 
 ///|
 /// Create a new model configuration describing how to reach a provider

--- a/model/pkg.generated.mbti
+++ b/model/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/model"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -91,7 +92,7 @@ pub struct Model {
   account_id : String?
   refresh_token : String?
   id_token : String?
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 #as_free_fn
 pub fn Model::new(api_key~ : String, base_url~ : String, name~ : String, safe_zone_tokens~ : Int, model_name? : String, model_type? : Type, description? : String, supports_anthropic_prompt_caching? : Bool, access_token? : String, account_id? : String, refresh_token? : String, id_token? : String) -> Self
 pub impl @json.FromJson for Model
@@ -100,11 +101,11 @@ pub(all) enum Provider {
   OpenAI
   CodexOAuth
   Copilot
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 
 pub(all) enum Type {
   SaaS(Provider)
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 pub impl ToJson for Type
 pub impl @json.FromJson for Type
 

--- a/oauth/codex/credentials.mbt
+++ b/oauth/codex/credentials.mbt
@@ -7,14 +7,14 @@ pub(all) struct Credentials {
   accessToken : String
   refreshToken : String
   accountId : String
-} derive(Show, ToJson, FromJson)
+} derive(Debug, ToJson, FromJson)
 
 ///|
 pub struct IdTokenClaims {
   email : String
   chatgptAccountId : String
   chatgptPlanType : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 fn add_base64_padding(s : String) -> String {

--- a/oauth/codex/error.mbt
+++ b/oauth/codex/error.mbt
@@ -1,7 +1,7 @@
 ///|
 priv suberror OAuthError {
   OAuthError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 priv suberror ParseError {

--- a/oauth/codex/oauth.mbt
+++ b/oauth/codex/oauth.mbt
@@ -3,7 +3,7 @@ pub struct TokenResponse {
   id_token : String
   access_token : String
   refresh_token : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl @json.FromJson for TokenResponse with from_json(

--- a/oauth/codex/pkce.mbt
+++ b/oauth/codex/pkce.mbt
@@ -2,7 +2,7 @@
 pub struct PkceCodes {
   code_verifier : String
   code_challenge : String
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn PkceCodes::new(

--- a/oauth/codex/pkg.generated.mbti
+++ b/oauth/codex/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/oauth/codex"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -40,27 +41,27 @@ pub(all) struct Credentials {
   accessToken : String
   refreshToken : String
   accountId : String
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 
 pub struct IdTokenClaims {
   email : String
   chatgptAccountId : String
   chatgptPlanType : String
-} derive(Show)
+} derive(@debug.Debug)
 
 pub struct PkceCodes {
   code_verifier : String
   code_challenge : String
-} derive(Show)
+} derive(@debug.Debug)
 pub fn PkceCodes::new(code_verifier~ : String, code_challenge~ : String) -> Self
 
-type RefreshResponse derive(Show)
+type RefreshResponse derive(@debug.Debug)
 
 pub struct TokenResponse {
   id_token : String
   access_token : String
   refresh_token : String
-} derive(Show)
+} derive(@debug.Debug)
 
 // Type aliases
 

--- a/oauth/codex/refresh.mbt
+++ b/oauth/codex/refresh.mbt
@@ -3,7 +3,7 @@ struct RefreshResponse {
   id_token : String?
   access_token : String?
   refresh_token : String?
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl @json.FromJson for RefreshResponse with from_json(

--- a/oauth/copilot/credentials.mbt
+++ b/oauth/copilot/credentials.mbt
@@ -6,7 +6,7 @@ pub(all) struct Credentials {
   github_token : String
   copilot_token : String
   copilot_token_expires_at : Int64
-} derive(Show, ToJson, FromJson)
+} derive(Debug, ToJson, FromJson)
 
 ///|
 fn get_home() -> String {

--- a/oauth/copilot/error.mbt
+++ b/oauth/copilot/error.mbt
@@ -1,7 +1,7 @@
 ///|
 priv suberror CopilotOAuthError {
   CopilotOAuthError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 priv suberror ParseError {

--- a/oauth/copilot/oauth.mbt
+++ b/oauth/copilot/oauth.mbt
@@ -5,7 +5,7 @@ pub struct DeviceCodeResponse {
   verification_uri : String
   expires_in : Int
   interval : Int
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl @json.FromJson for DeviceCodeResponse with from_json(
@@ -54,7 +54,7 @@ impl @json.FromJson for DeviceCodeResponse with from_json(
 struct AccessTokenResponse {
   access_token : String?
   error : String?
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl @json.FromJson for AccessTokenResponse with from_json(
@@ -79,7 +79,7 @@ impl @json.FromJson for AccessTokenResponse with from_json(
 pub struct CopilotTokenResponse {
   token : String
   expires_at : Int64
-} derive(Show)
+} derive(Debug)
 
 ///|
 impl @json.FromJson for CopilotTokenResponse with from_json(

--- a/oauth/copilot/pkg.generated.mbti
+++ b/oauth/copilot/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/oauth/copilot"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 
@@ -29,18 +30,18 @@ pub async fn start_oauth_flow() -> Credentials
 // Errors
 
 // Types and methods
-type AccessTokenResponse derive(Show)
+type AccessTokenResponse derive(@debug.Debug)
 
 pub struct CopilotTokenResponse {
   token : String
   expires_at : Int64
-} derive(Show)
+} derive(@debug.Debug)
 
 pub(all) struct Credentials {
   github_token : String
   copilot_token : String
   copilot_token_expires_at : Int64
-} derive(Show, ToJson, @json.FromJson)
+} derive(ToJson, @debug.Debug, @json.FromJson)
 pub fn Credentials::is_token_valid(Self, Int64) -> Bool
 
 pub struct DeviceCodeResponse {
@@ -49,7 +50,7 @@ pub struct DeviceCodeResponse {
   verification_uri : String
   expires_in : Int
   interval : Int
-} derive(Show)
+} derive(@debug.Debug)
 
 // Type aliases
 

--- a/tool/jsonschema.mbt
+++ b/tool/jsonschema.mbt
@@ -1,5 +1,5 @@
 ///|
-pub(all) struct JsonSchema(Json) derive(Eq, Show)
+pub(all) struct JsonSchema(Json) derive(Eq, Debug)
 
 ///|
 pub fn JsonSchema::from_json(schema : Json) -> JsonSchema {

--- a/tool/pkg.generated.mbti
+++ b/tool/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/tool"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/maria/ai",
   "moonbitlang/maria/internal/openai",
 }
@@ -16,7 +17,7 @@ type AgentTool
 pub async fn AgentTool::call(Self, Json) -> ToolResult noraise
 pub fn AgentTool::desc(Self) -> ToolDesc
 
-pub(all) struct JsonSchema(Json) derive(Eq, Show)
+pub(all) struct JsonSchema(Json) derive(Eq, @debug.Debug)
 pub fn JsonSchema::from_json(Json) -> Self
 pub impl ToJson for JsonSchema
 
@@ -34,7 +35,7 @@ pub struct ToolDesc {
   description : String
   name : String
   schema : JsonSchema
-} derive(Eq, Show, ToJson)
+} derive(Eq, ToJson, @debug.Debug)
 pub fn ToolDesc::to_openai(Self) -> @openai.ChatCompletionToolParam
 
 pub(all) struct ToolFn(async (Json) -> ToolResult noraise)

--- a/tool/tool.mbt
+++ b/tool/tool.mbt
@@ -3,7 +3,7 @@ pub struct ToolDesc {
   description : String
   name : String
   schema : JsonSchema
-} derive(ToJson, Eq, Show)
+} derive(ToJson, Eq, Debug)
 
 ///|
 pub fn ToolDesc::to_openai(

--- a/tools/apply_patch/executor.mbt
+++ b/tools/apply_patch/executor.mbt
@@ -4,7 +4,7 @@ using @path {type Path}
 ///|
 pub(all) suberror ApplyError {
   ApplyError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub async fn apply_hunks(

--- a/tools/apply_patch/pkg.generated.mbti
+++ b/tools/apply_patch/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/tools/apply_patch"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/maria/tool",
 }
 
@@ -17,19 +18,19 @@ pub let tool_instructions : String
 // Errors
 pub(all) suberror ApplyError {
   ApplyError(String)
-} derive(Show)
+} derive(@debug.Debug)
 
 pub(all) suberror ParseError {
   InvalidPatch(String)
   InvalidHunk(message~ : String, line_number~ : Int)
-} derive(Show)
+} derive(@debug.Debug)
 
 // Types and methods
 pub struct ApplyResult {
   added : Array[String]
   modified : Array[String]
   deleted : Array[String]
-} derive(Show)
+} derive(@debug.Debug)
 pub fn ApplyResult::new() -> Self
 pub fn ApplyResult::summary(Self) -> String
 
@@ -37,19 +38,19 @@ pub(all) enum Hunk {
   AddFile(path~ : String, contents~ : String)
   DeleteFile(path~ : String)
   UpdateFile(path~ : String, move_path~ : String?, chunks~ : Array[UpdateFileChunk])
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 
 pub struct ParsedPatch {
   patch : String
   hunks : Array[Hunk]
-} derive(Show)
+} derive(@debug.Debug)
 
 pub struct UpdateFileChunk {
   change_context : String?
   old_lines : Array[String]
   new_lines : Array[String]
   is_end_of_file : Bool
-} derive(Eq, Show)
+} derive(Eq, @debug.Debug)
 
 // Type aliases
 

--- a/tools/apply_patch/types.mbt
+++ b/tools/apply_patch/types.mbt
@@ -7,7 +7,7 @@ pub(all) enum Hunk {
     move_path~ : String?,
     chunks~ : Array[UpdateFileChunk]
   )
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub struct UpdateFileChunk {
@@ -15,26 +15,26 @@ pub struct UpdateFileChunk {
   old_lines : Array[String]
   new_lines : Array[String]
   is_end_of_file : Bool
-} derive(Show, Eq)
+} derive(Debug, Eq)
 
 ///|
 pub struct ParsedPatch {
   patch : String
   hunks : Array[Hunk]
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub(all) suberror ParseError {
   InvalidPatch(String)
   InvalidHunk(message~ : String, line_number~ : Int)
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub struct ApplyResult {
   added : Array[String]
   modified : Array[String]
   deleted : Array[String]
-} derive(Show)
+} derive(Debug)
 
 ///|
 pub fn ApplyResult::new() -> ApplyResult {

--- a/tools/search_files/tool.mbt
+++ b/tools/search_files/tool.mbt
@@ -15,7 +15,7 @@ priv struct SearchResult {
 priv suberror SearchError {
   FileReadError(path~ : String, error~ : String)
   MoonAnalysisError(query~ : String, error~ : String)
-} derive(ToJson, Show)
+} derive(ToJson, Debug)
 
 ///|
 /// Search kind enumeration

--- a/tools/todo/moon.pkg
+++ b/tools/todo/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/maria/internal/uuid",
   "moonbitlang/maria/clock",
   "moonbitlang/maria/tool",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/test",
 }

--- a/tools/todo/pkg.generated.mbti
+++ b/tools/todo/pkg.generated.mbti
@@ -2,6 +2,7 @@
 package "moonbitlang/maria/tools/todo"
 
 import {
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/maria/clock",
   "moonbitlang/maria/internal/uuid",
@@ -18,14 +19,14 @@ pub fn parse_todo_args(Json) -> TodoArgs raise TodoArgsError
 pub let prompt : String
 
 // Errors
-type TodoArgsError derive(Show)
+type TodoArgsError derive(@debug.Debug)
 
 // Types and methods
 type Items derive(Eq, ToJson, @json.FromJson)
 
 type Todo
 
-type TodoArgs derive(Show, ToJson)
+type TodoArgs derive(ToJson, @debug.Debug)
 
 type TodoResult derive(ToJson, @json.FromJson)
 pub impl Show for TodoResult

--- a/tools/todo/tool.mbt
+++ b/tools/todo/tool.mbt
@@ -141,7 +141,7 @@ priv enum Action {
   Update
   MarkProgress
   MarkCompleted
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// Parsed arguments from JSON input for todo operations
@@ -152,13 +152,13 @@ struct TodoArgs {
   priority : Priority
   status : Status
   notes : String?
-} derive(Show, ToJson)
+} derive(Debug, ToJson)
 
 ///|
 /// Parse error type for todo arguments
 suberror TodoArgsError {
   TodoArgsError(String)
-} derive(Show)
+} derive(Debug)
 
 ///|
 /// Parse JSON arguments into TodoArgs

--- a/tools/todo/tool_args_test.mbt
+++ b/tools/todo/tool_args_test.mbt
@@ -166,7 +166,7 @@ test "parse_todo_args/error_missing_action" {
   let result : Result[TodoArgs, TodoArgsError] = Ok(parse_todo_args(args)) catch {
     e => Err(e)
   }
-  inspect(
+  @debug.debug_inspect(
     result,
     content="Err(TodoArgsError(\"Error: 'action' parameter is required\"))",
   )
@@ -178,7 +178,7 @@ test "parse_todo_args/error_invalid_action" {
   let result : Result[TodoArgs, TodoArgsError] = Ok(parse_todo_args(args)) catch {
     e => Err(e)
   }
-  inspect(
+  @debug.debug_inspect(
     result,
     content="Err(TodoArgsError(\"Error: Invalid action 'invalid'. Supported actions: read, create, add_task, update, mark_progress, mark_completed.\"))",
   )
@@ -194,7 +194,7 @@ test "parse_todo_args/error_invalid_priority" {
   let result : Result[TodoArgs, TodoArgsError] = Ok(parse_todo_args(args)) catch {
     e => Err(e)
   }
-  inspect(
+  @debug.debug_inspect(
     result,
     content="Err(TodoArgsError(\"Error: Invalid priority 'String(\\\"urgent\\\")'. Must be 'high', 'medium', or 'low'.\"))",
   )
@@ -206,7 +206,7 @@ test "parse_todo_args/error_invalid_status" {
   let result : Result[TodoArgs, TodoArgsError] = Ok(parse_todo_args(args)) catch {
     e => Err(e)
   }
-  inspect(
+  @debug.debug_inspect(
     result,
     content="Err(TodoArgsError(\"Error: Invalid status 'String(\\\"done\\\")'. Must be 'pending', 'in_progress', or 'completed'.\"))",
   )

--- a/tools/todo/types.mbt
+++ b/tools/todo/types.mbt
@@ -25,14 +25,14 @@ priv enum Priority {
   High
   Medium
   Low
-} derive(ToJson, FromJson, Show, Eq)
+} derive(ToJson, FromJson, Debug, Eq)
 
 ///|
 priv enum Status {
   Pending
   InProgress
   Completed
-} derive(ToJson, FromJson, Show, Eq)
+} derive(ToJson, FromJson, Debug, Eq)
 
 ///|
 priv struct Item {


### PR DESCRIPTION
## Summary
- Replaces deprecated `derive(Show)` with `derive(Debug)` across all affected types
- Adds manual `@debug.Debug` impls for `@uuid.Uuid` and `@clock.Timestamp` (used as fields in types now deriving `Debug`)
- Updates a few call sites that relied on `Show`-based formatting:
  - `\{error}` interpolation of an error type now uses `@debug.to_string(error)` (in `internal/uuid/uuid.mbt` and `cmd/daemon/task_running.mbt`)
  - `assert_eq` on `Event`/`EventDesc` switched to `@debug.assert_eq` in `event/event_test.mbt`
  - `inspect` on `Result[TodoArgs, TodoArgsError]` switched to `@debug.debug_inspect` in `tools/todo/tool_args_test.mbt`
- Resolves the `derive(Show)` deprecated_syntax warning (61 -> 0) and the related 'Use Debug instead of Show' warnings tied to these types. The 23 'Use Debug' warnings that remain are pre-existing on stdlib types (e.g. `assert_eq(x, Some(8443))` on `Option[Int]`, string interpolation of `Option[String]`) and are unrelated to this change.

## Test plan
- [x] `moon check` reports 0 `derive(Show)` warnings (was 61)
- [x] `moon check` reports no NEW `Use Debug instead of Show` warnings introduced (23 remain, all pre-existing)
- [x] `moon check --deny-warn` introduces no new errors compared to baseline (51 vs 57)
- [x] `moon test` results unchanged: same 6 pre-existing failures (HTTP 403 region restrictions on external API tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)