### PR TITLE
chore: update string escape

### DIFF
--- a/event/event_test.mbt
+++ b/event/event_test.mbt
@@ -432,7 +432,7 @@ test "Event::Roundtrip/PreToolCall" {
       inspect(
         tc.arguments,
         content=(
-          #|Some("{\"param1\": \"value1\", \"param2\": 123}")
+          #|Some({"param1": "value1", "param2": 123})
         ),
       )
     }
@@ -461,7 +461,7 @@ test "Event::Roundtrip/PostToolCall/Ok" {
       inspect(
         result,
         content=(
-          #|Ok(Object({"output": String("success")}))
+          #|Ok(Object({output: String(success)}))
         ),
       )
       inspect(rendered, content="Tool output: success")
@@ -490,7 +490,7 @@ test "Event::Roundtrip/PostToolCall/Err" {
       inspect(
         result,
         content=(
-          #|Err(Object({"error": String("Something went wrong")}))
+          #|Err(Object({error: String(Something went wrong)}))
         ),
       )
       inspect(rendered, content="Error occurred")
@@ -511,7 +511,7 @@ test "Event::Roundtrip/SystemPromptSet/Some" {
       inspect(
         msg,
         content=(
-          #|Some("You are a helpful assistant.")
+          #|Some(You are a helpful assistant.)
         ),
       )
     _ => fail("Expected SystemPromptSet")
@@ -572,7 +572,7 @@ test "Event::Roundtrip/ToolAdded" {
       inspect(
         desc.schema.to_json(),
         content=(
-          #|Object({"type": String("object")})
+          #|Object({type: String(object)})
         ),
       )
     }

--- a/internal/git/repo_root_test.mbt
+++ b/internal/git/repo_root_test.mbt
@@ -16,14 +16,18 @@ async test "find_repo_root" (t : @test.Test) {
     @git.init_(mock.cwd.path())
     inspect(
       mock.show(@git.find_repo_root(mock.cwd.path())),
-      content="Some(\"(mock:cwd)\")",
+      content=(
+        #|Some((mock:cwd))
+      ),
     )
 
     // Subdirectory in a git repo
     let sub = mock.cwd.add_directory("sub")
     inspect(
       mock.show(@git.find_repo_root(sub.path())),
-      content="Some(\"(mock:cwd)\")",
+      content=(
+        #|Some((mock:cwd))
+      ),
     )
 
     // File path in a git repo
@@ -31,7 +35,9 @@ async test "find_repo_root" (t : @test.Test) {
     file.write_string("hello")
     inspect(
       mock.show(@git.find_repo_root(file.path())),
-      content="Some(\"(mock:cwd)\")",
+      content=(
+        #|Some((mock:cwd))
+      ),
     )
   })
 }

--- a/internal/httpx/header_test.mbt
+++ b/internal/httpx/header_test.mbt
@@ -7,7 +7,7 @@ test "header" {
   inspect(
     header,
     content=(
-      #|{"Content-Type": "application/json", "Set-Cookie": "sessionid=abc123, theme=dark"}
+      #|{Content-Type: application/json, Set-Cookie: sessionid=abc123, theme=dark}
     ),
   )
   json_inspect(header, content={

--- a/tools/replace_in_file/replace_in_file_test.mbt
+++ b/tools/replace_in_file/replace_in_file_test.mbt
@@ -10,7 +10,7 @@ async test "replace_in_file/create" (t : @test.Test) {
     json_inspect(result, content=[
       "Failed",
       [
-        "ToolFailure", "Error: Invalid arguments provided to replace_in_file tool: JsonDecodeError((, \"Missing field replace\"))",
+        "ToolFailure", "Error: Invalid arguments provided to replace_in_file tool: JsonDecodeError((, Missing field replace))",
       ],
     ])
   })

--- a/tools/todo/tool_args_test.mbt
+++ b/tools/todo/tool_args_test.mbt
@@ -196,7 +196,9 @@ test "parse_todo_args/error_invalid_priority" {
   }
   @debug.debug_inspect(
     result,
-    content="Err(TodoArgsError(\"Error: Invalid priority 'String(\\\"urgent\\\")'. Must be 'high', 'medium', or 'low'.\"))",
+    content=(
+      #|Err(TodoArgsError("Error: Invalid priority 'String(urgent)'. Must be 'high', 'medium', or 'low'."))
+    ),
   )
 }
 
@@ -208,7 +210,9 @@ test "parse_todo_args/error_invalid_status" {
   }
   @debug.debug_inspect(
     result,
-    content="Err(TodoArgsError(\"Error: Invalid status 'String(\\\"done\\\")'. Must be 'pending', 'in_progress', or 'completed'.\"))",
+    content=(
+      #|Err(TodoArgsError("Error: Invalid status 'String(done)'. Must be 'pending', 'in_progress', or 'completed'."))
+    ),
   )
 }
 

--- a/tools/todo/tool_test.mbt
+++ b/tools/todo/tool_test.mbt
@@ -903,13 +903,13 @@ async test "todo_write/error_invalid_priority" (t : @test.Test) {
     json_inspect(result, content=[
       "Failed",
       [
-        "ToolFailure", "Error: Invalid priority 'String(\"urgent\")'. Must be 'high', 'medium', or 'low'.",
+        "ToolFailure", "Error: Invalid priority 'String(urgent)'. Must be 'high', 'medium', or 'low'.",
       ],
     ])
     inspect(
       result,
       content=(
-        #|Error: Invalid priority 'String("urgent")'. Must be 'high', 'medium', or 'low'.
+        #|Error: Invalid priority 'String(urgent)'. Must be 'high', 'medium', or 'low'.
       ),
     )
   })
@@ -927,13 +927,13 @@ async test "todo_write/error_invalid_status" (t : @test.Test) {
     json_inspect(result, content=[
       "Failed",
       [
-        "ToolFailure", "Error: Invalid status 'String(\"done\")'. Must be 'pending', 'in_progress', or 'completed'.",
+        "ToolFailure", "Error: Invalid status 'String(done)'. Must be 'pending', 'in_progress', or 'completed'.",
       ],
     ])
     inspect(
       result,
       content=(
-        #|Error: Invalid status 'String("done")'. Must be 'pending', 'in_progress', or 'completed'.
+        #|Error: Invalid status 'String(done)'. Must be 'pending', 'in_progress', or 'completed'.
       ),
     )
   })


### PR DESCRIPTION
New MoonBit toolchain introduce unquoted `Show` implementation for type `String`. We update all these snapshots here since they are all valid candidates for debug_inspect, and therefore the formatting of the output does not matter and can be converted to use `debug_inspect`.