### PR TITLE
[codex] Migrate Ref constructor usage

### DIFF
--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -130,7 +130,7 @@ async test "track-conversation" {
 ///|
 async test "track-tool-calls" {
   let agent = @agent.new(model, cwd=@os.cwd())
-  let tool_calls = Ref::new([])
+  let tool_calls = Ref([])
   agent.add_listener(event => {
     match event.desc {
       PreToolCall(tool_call) => {

--- a/cmd/daemon/daemon_auth_codex.mbt
+++ b/cmd/daemon/daemon_auth_codex.mbt
@@ -35,7 +35,7 @@ async fn Daemon::start_codex_auth(
 /// Spawns a temporary HTTP server on port 1455 to handle the OAuth callback
 /// from OpenAI. The server shuts down after handling one callback.
 async fn Daemon::spawn_codex_callback_server(self : Daemon) -> Unit {
-  let done = Ref::new(false)
+  let done = Ref(false)
   let pending_auth = self.pending_codex_auth
   let events = self.events
   let router = @httpx.Router::new()

--- a/cmd/jsonl2md/formatter_wbtest.mbt
+++ b/cmd/jsonl2md/formatter_wbtest.mbt
@@ -311,7 +311,7 @@ test "recover_diagnostics" {
       #|fn new_parser(text : String) -> Parser {
       #|  Parser {
       #|    text: text,
-      #|    pos: Ref::new(0)
+      #|    pos: Ref(0)
       #|  }
       #|}
       #|
@@ -885,7 +885,7 @@ test "recover_diagnostics" {
       #|fn new_parser(text : String) -> Parser {
       #|  Parser {
       #|    text: text,
-      #|    pos: Ref::new(0)
+      #|    pos: Ref(0)
       #|  }
       #|}
       #|

--- a/internal/openai/ai.mbt
+++ b/internal/openai/ai.mbt
@@ -122,9 +122,9 @@ async fn chat_codex(
           )
       }
   }
-  let has_refreshed = Ref::new(false)
-  let current_access_token = Ref::new(access_token)
-  let current_account_id = Ref::new(account_id)
+  let has_refreshed = Ref(false)
+  let current_access_token = Ref(access_token)
+  let current_account_id = Ref(account_id)
   @async.retry(
     ExponentialDelay(initial=1000, factor=2.0, maximum=16000),
     max_retry=5,
@@ -220,8 +220,8 @@ async fn chat_copilot(
         body="Failed to get Copilot credentials: \{err}",
       )
   }
-  let has_refreshed = Ref::new(false)
-  let current_token = Ref::new(credentials.copilot_token)
+  let has_refreshed = Ref(false)
+  let current_token = Ref(credentials.copilot_token)
   @async.retry(
     ExponentialDelay(initial=1000, factor=2.0, maximum=16000),
     max_retry=5,

--- a/internal/os/os.mbt
+++ b/internal/os/os.mbt
@@ -106,7 +106,7 @@ pub fn home() -> String raise {
   let pwd : FixedArray[Byte] = FixedArray::make(os_passwd_sizeof(), 0)
   let buf_len = sysconf_SC_GETPW_R_SIZE_MAX().to_uint64()
   let buf : @c.Pointer[Byte] = @c.malloc(buf_len)
-  let result : Ref[@c.Pointer[Unit]] = Ref::new(@c.Pointer::null())
+  let result : Ref[@c.Pointer[Unit]] = Ref(@c.Pointer::null())
   let errno = os_getpwuid_r(uid, pwd, buf, buf_len, result)
   if errno != 0 {
     raise @errno.Errno(errno)

--- a/internal/spawn/manager.mbt
+++ b/internal/spawn/manager.mbt
@@ -164,7 +164,7 @@ pub async fn Manager::start(self : Manager) -> Unit {
       let spawn = self.spawn.get()
       try {
         let pid = self.new_pid()
-        let refer_status = Ref::new(None)
+        let refer_status = Ref(None)
         let stderr = redirect_output(spawn.stderr)
         let stdout = redirect_output(spawn.stdout)
         let task = group.spawn(() => {

--- a/oauth/codex/oauth.mbt
+++ b/oauth/codex/oauth.mbt
@@ -183,9 +183,9 @@ pub fn parse_query_string(query : StringView) -> Map[String, String] {
 pub async fn start_oauth_flow() -> Credentials raise Error {
   let pkce = generate_pkce()
   let state = generate_state()
-  let result : Ref[Credentials?] = Ref::new(None)
-  let error_ref : Ref[Error?] = Ref::new(None)
-  let done = Ref::new(false)
+  let result : Ref[Credentials?] = Ref(None)
+  let error_ref : Ref[Error?] = Ref(None)
+  let done = Ref(false)
   let auth_url = build_authorize_url(pkce, state)
   println("\nOpen this URL in your browser to login:\n")
   println("   \{auth_url}\n")

--- a/tools/search_files/tool.mbt
+++ b/tools/search_files/tool.mbt
@@ -424,7 +424,7 @@ async fn search_files_impl(
           let regex_result = @regexp.compile(search_pattern) catch {
             error => return @tool.failed("Invalid regex pattern: \{error}")
           }
-          let does_respect_gitignore = Ref::new(true)
+          let does_respect_gitignore = Ref(true)
 
           // Collect files to search
           let files_to_search = if is_file {


### PR DESCRIPTION
## Summary

- Replace `Ref::new(...)` call sites with direct `Ref(...)` construction.
- Update the README example and formatter recovery fixtures to match the new constructor form.

## Impact

This is a behavior-preserving syntax migration. `moon info` produced no `.mbti` diffs, so there is no intended public API change.

## Validation

- `moon check`
- `moon test` (483 passed, 0 failed)
- `moon info`
- `moon fmt`
